### PR TITLE
dev: make vagrant env survive between compiles

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -85,6 +85,10 @@ type Context struct {
 	// this cache directory can be cleared at any time between runs.
 	CacheDir string
 
+	// LocalDir is the directory where data local to this single Appfile
+	// will be stored; it isn't cleared for compilation.
+	LocalDir string
+
 	// Tuple is the Tuple that identifies this application. This can be
 	// used so that an implementatin of App can work with multiple tuple
 	// types.

--- a/helper/vagrant/vagrant.go
+++ b/helper/vagrant/vagrant.go
@@ -2,7 +2,9 @@ package vagrant
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"sync"
 
 	execHelper "github.com/hashicorp/otto/helper/exec"
 	"github.com/hashicorp/otto/ui"
@@ -14,17 +16,37 @@ type Vagrant struct {
 	// be executed from.
 	Dir string
 
+	// DataDir is the directory where Vagrant commands should store data.
+	DataDir string
+
 	// Ui, if given, will be used to stream output from the Vagrant
 	// commands. If this is nil, then the output will be logged but
 	// won't be visible to the user.
 	Ui ui.Ui
 }
 
+// A global mutex to prevent any Vagrant commands from running in parallel,
+// which is not a supported mode of operation for Vagrant.
+var vagrantMutex = &sync.Mutex{}
+
+// The environment variable that Vagrant uses to configure its data dir.
+const vagrantDataDirEnvVar = "VAGRANT_DOTFILE_PATH"
+
 // Execute executes a raw Vagrant command.
 func (v *Vagrant) Execute(command ...string) error {
+	vagrantMutex.Lock()
+	defer vagrantMutex.Unlock()
+
 	// Build the command to execute
 	cmd := exec.Command("vagrant", command...)
 	cmd.Dir = v.Dir
+
+	// Tell vagrant where to store data
+	origDataDir := os.Getenv(vagrantDataDirEnvVar)
+	defer os.Setenv(vagrantDataDirEnvVar, origDataDir)
+	if err := os.Setenv(vagrantDataDirEnvVar, v.DataDir); err != nil {
+		return err
+	}
 
 	// Run it with the execHelper
 	if err := execHelper.Run(v.Ui, cmd); err != nil {

--- a/otto/core.go
+++ b/otto/core.go
@@ -549,6 +549,7 @@ func (c *Core) appContext(f *appfile.File) (*app.Context, error) {
 	return &app.Context{
 		Dir:         outputDir,
 		CacheDir:    cacheDir,
+		LocalDir:    c.localDir,
 		Tuple:       tuple,
 		Appfile:     f,
 		Application: f.Application,


### PR DESCRIPTION
- plumb the LocalDir, which is preserved between compiles down to the
  app's context
- add a SetupFunc feature to app Router so we have a place to configure
  the vagrant data dir
- set VAGRANT_DOTFILE_PATH to live inside the LocalDir
