### PR TITLE
helper/exec: allow skipping cleanup for debugging

### DIFF
--- a/helper/exec/exec.go
+++ b/helper/exec/exec.go
@@ -41,7 +41,8 @@ func Run(uiVal ui.Ui, cmd *exec.Cmd) error {
 	}()
 
 	// Run the command
-	log.Printf("[DEBUG] exec: %s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	log.Printf("[DEBUG] execDir: %s", cmd.Dir)
+	log.Printf("[DEBUG] exec: %s %s", cmd.Path, strings.Join(cmd.Args[1:], " "))
 	err := cmd.Run()
 
 	// Wait for all the output to finish
@@ -53,4 +54,15 @@ func Run(uiVal ui.Ui, cmd *exec.Cmd) error {
 
 	// Return the output from the command
 	return err
+}
+
+// OttoSkipCleanupEnvVar, when set, tells Otto to avoid cleaning up its
+// temporary workspace files, which can be helpful for debugging.
+const OttoSkipCleanupEnvVar = "OTTO_SKIP_CLEANUP"
+
+// ShouldCleanup returns true for normal operation. It returns false if the
+// user requested that Otto avoid cleaning up its temporary files for
+// debugging purposes.
+func ShouldCleanup() bool {
+	return os.Getenv(OttoSkipCleanupEnvVar) == ""
 }

--- a/helper/packer/packer.go
+++ b/helper/packer/packer.go
@@ -35,7 +35,9 @@ func (p *Packer) Execute(commandRaw ...string) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(varfile)
+	if execHelper.ShouldCleanup() {
+		defer os.Remove(varfile)
+	}
 
 	// The command must always be machine-readable. We use this
 	// exclusively to mirror the UI output.

--- a/helper/terraform/terraform.go
+++ b/helper/terraform/terraform.go
@@ -53,7 +53,9 @@ func (t *Terraform) Execute(commandRaw ...string) error {
 		if err != nil {
 			return err
 		}
-		defer os.Remove(varfile)
+		if execHelper.ShouldCleanup() {
+			defer os.Remove(varfile)
+		}
 
 		// Append the varfile onto our command.
 		command = append(command, "-var-file", varfile)
@@ -68,7 +70,9 @@ func (t *Terraform) Execute(commandRaw ...string) error {
 		if err != nil {
 			return err
 		}
-		defer os.RemoveAll(stateDir)
+		if execHelper.ShouldCleanup() {
+			defer os.RemoveAll(stateDir)
+		}
 
 		// State path
 		stateOldPath := filepath.Join(stateDir, "state.old")
@@ -147,7 +151,9 @@ func (t *Terraform) Outputs() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(tf.Name())
+	if execHelper.ShouldCleanup() {
+		defer os.Remove(tf.Name())
+	}
 
 	// Read the state from the directory and put it on disk. Lots of
 	// careful management of file handles here.


### PR DESCRIPTION
It's difficult to reproduce the context in which Otto executes Terraform
and Packer, because it generates a bunch of files that it uses to pass
into the tools, and then immediately removes them.

This adds support for `OTTO_SKIP_CLEANUP`, which, when used in concert
with `OTTO_LOG`, allows us to see precisely the commands that Otto runs
and reproduce them afterwards.

Example use case I wanted this for: get the context for `otto deploy`
and rerun the command flipping `apply` for `destroy` to work around the
lack of that feature at the moment.

Also tweaks the execHelper debug output to include CWD and avoid
double-printing the executable name.
