### PR TITLE
core: rework `otto deploy` into a command with actions

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"fmt"
+	"log"
 )
 
 // Router is a helper to route actions on the Context to specific callbacks.
@@ -40,6 +41,7 @@ func (r *Router) Route(ctx *Context) error {
 
 	action, ok := r.Actions[ctx.Action]
 	if !ok {
+		log.Printf("[DEBUG] No action found: %q; executing help.", ctx.Action)
 		return r.help(ctx)
 	}
 

--- a/builtin/app/custom/app.go
+++ b/builtin/app/custom/app.go
@@ -146,10 +146,10 @@ func (a *App) Deploy(ctx *app.Context) error {
 	}
 
 	// But if we did, then deploy using Terraform
-	return terraform.Deploy(ctx, &terraform.DeployOptions{
+	return terraform.Deploy(&terraform.DeployOptions{
 		Dir:          tfdir,
 		DisableBuild: disableBuild,
-	})
+	}).Route(ctx)
 }
 
 func (a *App) Dev(ctx *app.Context) error {

--- a/builtin/app/go/app.go
+++ b/builtin/app/go/app.go
@@ -79,7 +79,7 @@ func (a *App) Build(ctx *app.Context) error {
 }
 
 func (a *App) Deploy(ctx *app.Context) error {
-	return terraform.Deploy(ctx, &terraform.DeployOptions{})
+	return terraform.Deploy(&terraform.DeployOptions{}).Route(ctx)
 }
 
 func (a *App) Dev(ctx *app.Context) error {

--- a/builtin/app/ruby/app.go
+++ b/builtin/app/ruby/app.go
@@ -54,13 +54,13 @@ func (a *App) Build(ctx *app.Context) error {
 }
 
 func (a *App) Deploy(ctx *app.Context) error {
-	return terraform.Deploy(ctx, &terraform.DeployOptions{
+	return terraform.Deploy(&terraform.DeployOptions{
 		InfraOutputMap: map[string]string{
 			"region":         "aws_region",
 			"subnet-private": "private_subnet_id",
 			"subnet-public":  "public_subnet_id",
 		},
-	})
+	}).Route(ctx)
 }
 
 func (a *App) Dev(ctx *app.Context) error {


### PR DESCRIPTION
- use a Router in terraform.Deploy like vagrant.Dev does
- update builtin apps to conform to new API
- rewire command/deploy to properly parse out the subcommand
- add deploy plumbing to Core.Execute

It seemed like I had to change too many places to get this done; there's
likely further refactoring necessary in this overall flow to fix that up
in the future.
