### PR TITLE
otto deploy destroy

### DIFF
--- a/directory/deploy.go
+++ b/directory/deploy.go
@@ -34,6 +34,26 @@ type Deploy struct {
 	ID string
 }
 
+// IsNew reports if this deploy is freshly created and not yet run
+func (d *Deploy) IsNew() bool {
+	return d != nil && d.State == DeployStateNew
+}
+
+// MarkFailed sets a deploy's state to failed
+func (d *Deploy) MarkFailed() {
+	d.State = DeployStateFail
+}
+
+// MarkSuccess sets a deploy's state to success
+func (d *Deploy) MarkSuccessful() {
+	d.State = DeployStateSuccess
+}
+
+// MarkGone resets a deploy's state to the "new" state
+func (d *Deploy) MarkGone() {
+	d.State = DeployStateNew
+}
+
 func (d *Deploy) setId() {
 	d.ID = uuid.GenerateUUID()
 }

--- a/directory/infra.go
+++ b/directory/infra.go
@@ -42,6 +42,10 @@ type Infra struct {
 	ID string
 }
 
+func (i *Infra) IsReady() bool {
+	return i != nil && i.State == InfraStateReady
+}
+
 func (i *Infra) setId() {
 	i.ID = uuid.GenerateUUID()
 }

--- a/helper/terraform/deploy.go
+++ b/helper/terraform/deploy.go
@@ -46,6 +46,11 @@ func Deploy(opts *DeployOptions) *app.Router {
 				Synopsis: actionDeploySyn,
 				Help:     strings.TrimSpace(actionDeployHelp),
 			},
+			"destroy": &app.Action{
+				Execute:  opts.actionDestroy,
+				Synopsis: actionDestroySyn,
+				Help:     strings.TrimSpace(actionDestroyHelp),
+			},
 		},
 	}
 }
@@ -55,17 +60,13 @@ func (opts *DeployOptions) actionDeploy(ctx *app.Context) error {
 	if err := project.InstallIfNeeded(); err != nil {
 		return err
 	}
+	vars := make(map[string]string)
 
-	// Get the infrastructure state. The infrastructure must be
-	// created for us to deploy to it.
-	infra, err := ctx.Directory.GetInfra(&directory.Infra{
-		Lookup: directory.Lookup{
-			Infra: ctx.Appfile.ActiveInfrastructure().Name}})
+	infra, infraVars, err := opts.lookupInfraVars(ctx)
 	if err != nil {
 		return err
 	}
-
-	if infra == nil || infra.State != directory.InfraStateReady {
+	if infra == nil {
 		return fmt.Errorf(
 			"Infrastructure for this application hasn't been built yet.\n" +
 				"The deploy step requires this because the target infrastructure\n" +
@@ -73,8 +74,153 @@ func (opts *DeployOptions) actionDeploy(ctx *app.Context) error {
 				"Please run `otto infra` to build the underlying infrastructure,\n" +
 				"then run `otto deploy` again.")
 	}
+	for k, v := range infraVars {
+		vars[k] = v
+	}
 
-	// Construct the variables for Terraform from our queried infra
+	if !opts.DisableBuild {
+		buildVars, err := opts.lookupBuildVars(ctx, infra)
+		if err != nil {
+			return err
+		}
+		if buildVars == nil {
+			return fmt.Errorf(
+				"This application hasn't been built yet. Please run `otto build`\n" +
+					"first so that the deploy step has an artifact to deploy.")
+		}
+		for k, v := range buildVars {
+			vars[k] = v
+		}
+	}
+
+	// Get our old deploy to populate the old state data if we have it.
+	// This step is critical to make sure that Terraform remains idempotent
+	// and that it handles migrations properly.
+	deploy, err := opts.lookupDeploy(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Run Terraform!
+	tf := &Terraform{
+		Path:      project.Path(),
+		Dir:       opts.tfDir(ctx),
+		Ui:        ctx.Ui,
+		Variables: vars,
+		Directory: ctx.Directory,
+		StateId:   deploy.ID,
+	}
+	if err := tf.Execute("apply"); err != nil {
+		deploy.MarkFailed()
+		if putErr := ctx.Directory.PutDeploy(deploy); putErr != nil {
+			return fmt.Errorf("The deploy failed with err: %s\n\n"+
+				"And then there was an error storing it in the directory: %s\n"+
+				"This second error is a bug and should be reported.", err, putErr)
+		}
+
+		return fmt.Errorf(
+			"Error running Terraform: %s\n\n"+
+				"Terraform usually has helpful error messages. Please read the error\n"+
+				"messages above and resolve them. Sometimes simply running `otto deploy`\n"+
+				"again will work.", err)
+	}
+
+	deploy.MarkSuccessful()
+	if err := ctx.Directory.PutDeploy(deploy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (opts *DeployOptions) actionDestroy(ctx *app.Context) error {
+	project := Project(&ctx.Shared)
+	vars := make(map[string]string)
+
+	infra, infraVars, err := opts.lookupInfraVars(ctx)
+	if err != nil {
+		return err
+	}
+	if infra == nil {
+		return fmt.Errorf(
+			"Infrastructure for this application hasn't been built yet.\n" +
+				"Nothing to destroy.")
+	}
+	for k, v := range infraVars {
+		vars[k] = v
+	}
+
+	buildVars, err := opts.lookupBuildVars(ctx, infra)
+	if err != nil {
+		return err
+	}
+	if buildVars == nil {
+		return fmt.Errorf(
+			"This application hasn't been built yet. Nothing to destroy.")
+	}
+	for k, v := range buildVars {
+		vars[k] = v
+	}
+
+	deploy, err := opts.lookupDeploy(ctx)
+	if err != nil {
+		return err
+	}
+	if deploy.IsNew() {
+		return fmt.Errorf(
+			"This application hasn't been deployed yet. Nothing to destroy.")
+	}
+
+	// Get the directory
+	// Run Terraform!
+	tf := &Terraform{
+		Path:      project.Path(),
+		Dir:       opts.tfDir(ctx),
+		Ui:        ctx.Ui,
+		Variables: vars,
+		Directory: ctx.Directory,
+		StateId:   deploy.ID,
+	}
+	if err := tf.Execute("destroy"); err != nil {
+		deploy.MarkFailed()
+		if putErr := ctx.Directory.PutDeploy(deploy); putErr != nil {
+			return fmt.Errorf("The destroy failed with err: %s\n\n"+
+				"And then there was an error storing it in the directory: %s\n"+
+				"This second error is a bug and should be reported.", err, putErr)
+		}
+
+		return fmt.Errorf(
+			"Error running Terraform: %s\n\n"+
+				"Terraform usually has helpful error messages. Please read the error\n"+
+				"messages above and resolve them. Sometimes simply running `otto deply`\n"+
+				"again will work.",
+			err)
+	}
+
+	deploy.MarkGone()
+	if err := ctx.Directory.PutDeploy(deploy); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// lookupInfraVars collects information about the result of `otto infra` and
+// yields a set of variables that can be used by the deploy to reference
+// resources in the infrastructure. It returns `nil` if the infrastructure has
+// not been created successfully yet.
+func (opts *DeployOptions) lookupInfraVars(
+	ctx *app.Context) (*directory.Infra, map[string]string, error) {
+	infra, err := ctx.Directory.GetInfra(&directory.Infra{
+		Lookup: directory.Lookup{
+			Infra: ctx.Appfile.ActiveInfrastructure().Name}})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !infra.IsReady() {
+		return nil, nil, nil
+	}
+
 	vars := make(map[string]string)
 	for k, v := range infra.Outputs {
 		if opts.InfraOutputMap != nil {
@@ -87,70 +233,67 @@ func (opts *DeployOptions) actionDeploy(ctx *app.Context) error {
 	for k, v := range ctx.InfraCreds {
 		vars[k] = v
 	}
+	return infra, vars, nil
+}
 
-	if !opts.DisableBuild {
-		// Get the build information. We must have had a prior build in
-		// order to deploy.
-		build, err := ctx.Directory.GetBuild(&directory.Build{
-			Lookup: directory.Lookup{
-				AppID:       ctx.Appfile.ID,
-				Infra:       ctx.Tuple.Infra,
-				InfraFlavor: ctx.Tuple.InfraFlavor,
-			},
-		})
-		if err != nil {
-			return err
-		}
-		if build == nil {
-			return fmt.Errorf(
-				"This application hasn't been built yet. Please run `otto build`\n" +
-					"first so that the deploy step has an artifact to deploy.")
-		}
-
-		// Extract the artifact from the build. We do this based on the
-		// infrastructure type.
-		if opts.ArtifactExtractors == nil {
-			opts.ArtifactExtractors = make(map[string]DeployArtifactExtractor)
-		}
-		for k, v := range deployArtifactExtractors {
-			if _, ok := opts.ArtifactExtractors[k]; !ok {
-				opts.ArtifactExtractors[k] = v
-			}
-		}
-		ext, ok := opts.ArtifactExtractors[ctx.Tuple.Infra]
-		if !ok {
-			return fmt.Errorf(
-				"Unknown deployment target infrastructure: %s\n\n"+
-					"This app currently doesn't know how to deploy to this infrastructure.\n"+
-					"Please report this to the project.",
-				ctx.Tuple.Infra)
-		}
-		artifactVars, err := ext(ctx, build, infra)
-		if err != nil {
-			return err
-		}
-		for k, v := range artifactVars {
-			vars[k] = v
-		}
+// lookupBuildVars collects information about the result of `otto build` and
+// yields a set of variables that can be used by the deploy to reference the
+// built artifact. It returns nil if `otto build` has not yet been run.
+func (opts *DeployOptions) lookupBuildVars(
+	ctx *app.Context, infra *directory.Infra) (map[string]string, error) {
+	build, err := ctx.Directory.GetBuild(&directory.Build{
+		Lookup: directory.Lookup{
+			AppID:       ctx.Appfile.ID,
+			Infra:       ctx.Tuple.Infra,
+			InfraFlavor: ctx.Tuple.InfraFlavor,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if build == nil {
+		return nil, nil
 	}
 
-	// Get our old deploy to populate the old state data if we have it.
-	// This step is critical to make sure that Terraform remains idempotent
-	// and that it handles migrations properly.
-	//
-	// If we don't have a prior deploy, that is okay, we just create one
-	// now (with the DeployStateNew to note that we've never deployed). This
-	// gives us the UUID we can use for the state storage.
+	// Extract the artifact from the build. We do this based on the
+	// infrastructure type.
+	if opts.ArtifactExtractors == nil {
+		opts.ArtifactExtractors = make(map[string]DeployArtifactExtractor)
+	}
+	for k, v := range deployArtifactExtractors {
+		if _, ok := opts.ArtifactExtractors[k]; !ok {
+			opts.ArtifactExtractors[k] = v
+		}
+	}
+	ext, ok := opts.ArtifactExtractors[ctx.Tuple.Infra]
+	if !ok {
+		return nil, fmt.Errorf(
+			"Unknown deployment target infrastructure: %s\n\n"+
+				"This app currently doesn't know how to deploy to this infrastructure.\n"+
+				"Please report this to the project.",
+			ctx.Tuple.Infra)
+	}
+	return ext(ctx, build, infra)
+}
+
+// lookupDeploy returns any previously deploy made by Otto so we have the state
+// necessary to update it.
+//
+// If we don't have a prior deploy, that is okay, we just create one
+// now (with the DeployStateNew to note that we've never deployed). This
+// gives us the UUID we can use for the state storage.
+func (opts *DeployOptions) lookupDeploy(
+	ctx *app.Context) (*directory.Deploy, error) {
 	deployLookup := directory.Lookup{
 		AppID:       ctx.Appfile.ID,
 		Infra:       ctx.Tuple.Infra,
 		InfraFlavor: ctx.Tuple.InfraFlavor,
 	}
-	deploy, err := ctx.Directory.GetDeploy(&directory.Deploy{
-		Lookup: deployLookup})
+	deploy, err := ctx.Directory.GetDeploy(&directory.Deploy{Lookup: deployLookup})
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	if deploy == nil {
 		// If we have no deploy, put in a temporary one
 		deploy = &directory.Deploy{Lookup: deployLookup}
@@ -158,40 +301,26 @@ func (opts *DeployOptions) actionDeploy(ctx *app.Context) error {
 
 		// Write the temporary deploy so we have an ID to use for the state
 		if err := ctx.Directory.PutDeploy(deploy); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	// Get the directory
+	return deploy, nil
+}
+
+// tfDir returns the appropriate terraform working dir
+func (opts *DeployOptions) tfDir(ctx *app.Context) string {
 	tfDir := opts.Dir
 	if tfDir == "" {
 		tfDir = filepath.Join(ctx.Dir, "deploy")
 	}
-
-	// Run Terraform!
-	tf := &Terraform{
-		Path:      project.Path(),
-		Dir:       tfDir,
-		Ui:        ctx.Ui,
-		Variables: vars,
-		Directory: ctx.Directory,
-		StateId:   deploy.ID,
-	}
-	if err := tf.Execute("apply"); err != nil {
-		return fmt.Errorf(
-			"Error running Terraform: %s\n\n"+
-				"Terraform usually has helpful error messages. Please read the error\n"+
-				"messages above and resolve them. Sometimes simply running `otto deply`\n"+
-				"again will work.",
-			err)
-	}
-
-	return nil
+	return tfDir
 }
 
 // Synopsis text for actions
 const (
-	actionDeploySyn = "Deploy the latest built artifact into your infrastructure"
+	actionDeploySyn  = "Deploy the latest built artifact into your infrastructure"
+	actionDestroySyn = "Destroy all deployed resources for this application"
 )
 
 // Help text for actions
@@ -203,4 +332,14 @@ Usage: otto deploy
 	This command will take the latest built artifact and deploy it into your
 	infrastructure. Otto will create or replace any necessary resources required
 	to run your app.
+`
+
+const actionDestroyHelp = `
+Usage: otto deploy destroy
+
+  Destroys any deployed resources associated with this application.
+
+	This command will remove any previously-deployed resources from your
+	infrastructure. This must be run for all of apps in an infrastructure before
+	'otto infra destroy' will work.
 `


### PR DESCRIPTION
Implement `otto deploy destroy` to destroy all resources associated with
a deploy.

Notes:
- Needed to add post-deploy state bookkeeping to ensure the FSM makes
  sense. There was no need for it before since nobody was reading it.
- Did what I could to pull common code up between the two terraform
  actions. Not super pleased with it but better than full copy pasta.
- Pushing for messages-over-attributes for the directory structs with
  the thought that we can eventually work more interfaces in for unit
  testing. Hence the `Mark*` and `Is*` funcs.
