### PR TITLE
builtin/app: simplify aws-simple further by removing elbs

### DIFF
--- a/builtin/app/ruby/data/aws-simple/deploy/main.tf.tpl
+++ b/builtin/app/ruby/data/aws-simple/deploy/main.tf.tpl
@@ -18,25 +18,6 @@ provider "aws" {
   region     = "${var.aws_region}"
 }
 
-resource "aws_security_group" "elb" {
-  name = "{{ name }}-elb-${var.infra_id}"
-  vpc_id = "${var.vpc_id}"
-
-  egress {
-    protocol    = -1
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
 resource "aws_security_group" "app" {
   name   = "{{ name }}-${var.infra_id}"
   vpc_id = "${var.vpc_id}"
@@ -45,20 +26,6 @@ resource "aws_security_group" "app" {
     protocol    = -1
     from_port   = 0
     to_port     = 0
-    cidr_blocks = ["${var.vpc_cidr}"]
-  }
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 22
-    to_port     = 22
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -70,22 +37,6 @@ resource "aws_security_group" "app" {
   }
 }
 
-resource "aws_elb" "app" {
-  name            = "{{ name }}-${var.infra_id}"
-  subnets         = ["${var.subnet_public}"]
-  security_groups = ["${aws_security_group.elb.id}"]
-  instances       = ["${aws_instance.app.*.id}"]
-
-  # TODO: make listening ports configurable
-  listener {
-    lb_port           = 80
-    lb_protocol       = "tcp"
-    instance_port     = 80
-    instance_protocol = "tcp"
-  }
-}
-
-# Deploy a set of instances
 resource "aws_instance" "app" {
   ami           = "${var.ami}"
   instance_type = "${var.instance_type}"
@@ -94,11 +45,9 @@ resource "aws_instance" "app" {
 
   vpc_security_group_ids = ["${aws_security_group.app.id}"]
 
-  tags {
-    Name = "{{ name }}"
-  }
+  tags { Name = "{{ name }}" }
 }
 
 output "url" {
-  value = "http://${aws_elb.app.dns_name}/"
+  value = "http://${aws_instance.app.public_dns}/"
 }

--- a/builtin/infra/aws/data/simple/main.tf
+++ b/builtin/infra/aws/data/simple/main.tf
@@ -26,6 +26,9 @@ provider "aws" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
   tags { Name = "otto" }
 }
 


### PR DESCRIPTION
- turn on DNS hostnames in the VPC
- remove the ELBs from deploy on node and ruby
- allow all in the app SG
- output the instance's hostname instead of the ELB's
