### PR TITLE
core: otto infra info

### DIFF
--- a/helper/terraform/deploy.go
+++ b/helper/terraform/deploy.go
@@ -405,7 +405,7 @@ Usage: otto deploy info [NAME]
 
   Displays information about this application's deploy.
 
-	This command will show any variables the deploy has specified as outputs. If
-	no NAME is specified, all outputs will be listed. If NAME is specified, just
-	the contents of that output will be printed.
+  This command will show any variables the deploy has specified as outputs. If
+  no NAME is specified, all outputs will be listed. If NAME is specified, just
+  the contents of that output will be printed.
 `

--- a/otto/core.go
+++ b/otto/core.go
@@ -420,8 +420,10 @@ func (c *Core) Infra(action string, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.creds(infra, infraCtx); err != nil {
-		return err
+	if action == "" || action == "destroy" {
+		if err := c.creds(infra, infraCtx); err != nil {
+			return err
+		}
 	}
 
 	// Set the action and action args
@@ -441,7 +443,6 @@ func (c *Core) Infra(action string, args []string) error {
 	// If we're doing anything other than destroying, then
 	// run the execution now.
 	if action != "destroy" {
-		c.ui.Header("Building main infrastructure...")
 		if err := infra.Execute(infraCtx); err != nil {
 			return err
 		}
@@ -481,7 +482,6 @@ func (c *Core) Infra(action string, args []string) error {
 	// we need to first destroy all applications and foundations that
 	// are using this infra.
 	if action == "destroy" {
-		c.ui.Header("Destroying main infrastructure...")
 		if err := infra.Execute(infraCtx); err != nil {
 			return err
 		}


### PR DESCRIPTION
- use router in terraform.Infrastructure to facilitate subcommands w/
  help
- move header printing down to individual terraform actions so we can
  skip it for info
- skip creds for non-infra-interacting subcommands
