### PR TITLE
command: ask for confirmation consistently on destroy

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -42,6 +42,14 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Destroy action gets an extra double-check
+	if action == "destroy" {
+		msg := "Otto will delete all resources associated with the deploy."
+		if !c.confirmDestroy(msg, execArgs) {
+			return 1
+		}
+	}
+
 	// Deploy the artifact
 	if err := core.Deploy(action, execArgs); err != nil {
 		// Display errors without prefix, we expect them to be formatted in a way

--- a/command/infra.go
+++ b/command/infra.go
@@ -43,6 +43,14 @@ func (c *InfraCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Destroy action gets an extra double-check
+	if action == "destroy" {
+		msg := "Otto will delete all your managed infrastructure."
+		if !c.confirmDestroy(msg, execArgs) {
+			return 1
+		}
+	}
+
 	// Execute the task
 	err = core.Infra(action, execArgs)
 	if err != nil {

--- a/helper/terraform/deploy.go
+++ b/helper/terraform/deploy.go
@@ -195,7 +195,7 @@ func (opts *DeployOptions) actionDestroy(rctx router.Context) error {
 		Directory: ctx.Directory,
 		StateId:   deploy.ID,
 	}
-	if err := tf.Execute("destroy"); err != nil {
+	if err := tf.Execute("destroy", "-force"); err != nil {
 		deploy.MarkFailed()
 		if putErr := ctx.Directory.PutDeploy(deploy); putErr != nil {
 			return fmt.Errorf("The destroy failed with err: %s\n\n"+
@@ -391,13 +391,16 @@ Usage: otto deploy
 `
 
 const actionDestroyHelp = `
-Usage: otto deploy destroy
+Usage: otto deploy destroy [-force]
 
   Destroys any deployed resources associated with this application.
 
   This command will remove any previously-deployed resources from your
   infrastructure. This must be run for all of apps in an infrastructure before
   'otto infra destroy' will work.
+
+	Otto will ask for confirmation to protect against an accidental destroy. You
+	can provide the -force flag to skip this check.
 `
 
 const actionInfoHelp = `

--- a/helper/terraform/infrastructure.go
+++ b/helper/terraform/infrastructure.go
@@ -64,7 +64,7 @@ func (i *Infrastructure) Execute(ctx *infrastructure.Context) error {
 func (i *Infrastructure) actionDestroy(rctx router.Context) error {
 	rctx.UI().Header("Destroying main infrastructure...")
 	ctx := rctx.(*infrastructure.Context)
-	return i.execute(ctx, "destroy")
+	return i.execute(ctx, "destroy", "-force")
 }
 
 func (i *Infrastructure) actionApply(rctx router.Context) error {
@@ -112,7 +112,7 @@ func (i *Infrastructure) actionInfo(rctx router.Context) error {
 	return nil
 }
 
-func (i *Infrastructure) execute(ctx *infrastructure.Context, command string) error {
+func (i *Infrastructure) execute(ctx *infrastructure.Context, command ...string) error {
 	project, err := Project(&ctx.Shared)
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (i *Infrastructure) execute(ctx *infrastructure.Context, command string) er
 			"\n\n")
 
 	// Start the Terraform command
-	err = tf.Execute(command)
+	err = tf.Execute(command...)
 	if err != nil {
 		err = fmt.Errorf("Error running Terraform: %s", err)
 		infra.State = directory.InfraStatePartial
@@ -258,13 +258,16 @@ Usage: otto infra
 `
 
 const infraDestroyHelp = `
-Usage: otto infra destroy
+Usage: otto infra destroy [-force]
 
   Destroys all infrastructure resources.
 
   This command will remove any previously-created infrastructure resources.
   Note that any apps with resources deployed into this infrastructure will need
   to have 'otto deploy destroy' run before this command will succeed.
+
+	Otto will ask for confirmation to protect against an accidental destroy. You
+	can provide the -force flag to skip this check.
 `
 
 const infraInfoHelp = `

--- a/website/source/docs/commands/deploy.html.md.erb
+++ b/website/source/docs/commands/deploy.html.md.erb
@@ -27,8 +27,9 @@ The available subcommands are:
  * `info` - Displays information about the deployed application. Otto outputs
    this information in `key = value` format. If you provide a key name as an
    additional argument, Otto will only print the value of that key.
- * `destroy` - Destroys the resources used to deploy this application. Each
-   application deployed to an infrastructure must be destroyed before the
-   [infra destroy command](/docs/commands/infra.html) will work.
+ * `destroy [-force]` - Destroys the resources used to deploy this application.
+   Each application deployed to an infrastructure must be destroyed before the
+   [infra destroy command](/docs/commands/infra.html) will work. Otto will ask
+   for confirmation unless the `-force` flag is specified.
 
 A list of these subcommands are also available via `otto deploy help`.

--- a/website/source/docs/commands/infra.html.md.erb
+++ b/website/source/docs/commands/infra.html.md.erb
@@ -27,11 +27,14 @@ fails for any reason.
 Once the infrastructure has been created, you can use the various available
 subcommands to interact with the running infrastructure.
 
- * `destroy` - Tears down all resources for this infrastructure. Note that you
-   must [destroy any deployed applications](/docs/commands/deploy.html) before
-   infrastructure can successfully be destroyed.
+ * `destroy [-force]` - Tears down all resources for this infrastructure. Note
+   that you must [destroy any deployed
+   applications](/docs/commands/deploy.html) before infrastructure can
+   successfully be destroyed. Otto will ask for confirmation unless the
+   `-force` flag is specified.
  * `info [key]` - Displays information about the infrastructure. Without a key,
-   Otto outputs all available information in `key = value` format. If you provide a key name as an
-   additional argument, Otto will only print the value of that key.
+   Otto outputs all available information in `key = value` format. If you
+   provide a key name as an additional argument, Otto will only print the value
+   of that key.
 
 A list of these subcommands are also available via `otto infra help`.


### PR DESCRIPTION
Instead of relying on Terraform behavior, we pull the destroy
confirmation up to Otto, and always pass `-force` down to Terraform when
the time comes.
