### PR TITLE
core, infra/aws, helper/terraform: verify creds

### DIFF
--- a/builtin/infra/aws/infra.go
+++ b/builtin/infra/aws/infra.go
@@ -3,8 +3,11 @@ package aws
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"strings"
 
 	"github.com/hashicorp/otto/helper/bindata"
+	"github.com/hashicorp/otto/helper/sshagent"
 	"github.com/hashicorp/otto/helper/terraform"
 	"github.com/hashicorp/otto/infrastructure"
 	"github.com/hashicorp/otto/ui"
@@ -17,7 +20,8 @@ import (
 // This function is a infrastructure.Factory.
 func Infra() (infrastructure.Infrastructure, error) {
 	return &terraform.Infrastructure{
-		CredsFunc: creds,
+		CredsFunc:       creds,
+		VerifyCredsFunc: verifyCreds,
 		Bindata: &bindata.Data{
 			Asset:    Asset,
 			AssetDir: AssetDir,
@@ -66,6 +70,7 @@ func creds(ctx *infrastructure.Context) (map[string]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error expanding homedir for SSH key: %s", err)
 	}
+
 	sshKey, err := ioutil.ReadFile(sshPath)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading SSH key: %s", err)
@@ -73,4 +78,74 @@ func creds(ctx *infrastructure.Context) (map[string]string, error) {
 	result["ssh_public_key"] = string(sshKey)
 
 	return result, nil
+}
+
+func verifyCreds(ctx *infrastructure.Context) error {
+	found, err := sshagent.HasKey(ctx.InfraCreds["ssh_public_key"])
+	if err != nil {
+		return sshAgentError(err)
+	}
+	if !found {
+		ok, _ := guessAndLoadPrivateKey(
+			ctx.Ui, ctx.InfraCreds["ssh_public_key_path"])
+		if ok {
+			ctx.Ui.Message(
+				"A private key was found and loaded. Otto will now check\n" +
+					"the SSH Agent again and continue if the correct key is loaded")
+
+			found, err = sshagent.HasKey(ctx.InfraCreds["ssh_public_key"])
+			if err != nil {
+				return sshAgentError(err)
+			}
+		}
+	}
+
+	if !found {
+		return sshAgentError(fmt.Errorf(
+			"You specified an SSH public key of: %q, but the private key from this\n"+
+				"keypair is not loaded the SSH Agent. To load it, run:\n\n"+
+				"  ssh-add [PATH_TO_PRIVATE_KEY]",
+			ctx.InfraCreds["ssh_public_key_path"]))
+	}
+	return nil
+}
+
+func sshAgentError(err error) error {
+	return fmt.Errorf(
+		"Otto uses your SSH Agent to authenticate with instances created in\n"+
+			"AWS, but it could not verify that your SSH key is loaded into the agent.\n"+
+			"The error message follows:\n\n%s", err)
+}
+
+// guessAndLoadPrivateKey takes a path to a public key and determines if a
+// private key exists by just stripping ".pub" from the end of it. if so,
+// it attempts to load that key into the agent.
+func guessAndLoadPrivateKey(ui ui.Ui, pubKeyPath string) (bool, error) {
+	fullPath, err := homedir.Expand(pubKeyPath)
+	if err != nil {
+		return false, err
+	}
+	if !strings.HasSuffix(fullPath, ".pub") {
+		return false, fmt.Errorf("No .pub suffix, cannot guess path.")
+	}
+	privKeyGuess := strings.TrimSuffix(fullPath, ".pub")
+	if _, err := os.Stat(privKeyGuess); os.IsNotExist(err) {
+		return false, fmt.Errorf("No file at guessed path.")
+	}
+
+	ui.Header("Loading key into SSH Agent")
+	ui.Message(fmt.Sprintf(
+		"The key you provided (%s) was not found in your SSH Agent.", pubKeyPath))
+	ui.Message(fmt.Sprintf(
+		"However, Otto found a private key here: %s", privKeyGuess))
+	ui.Message(fmt.Sprintf(
+		"Automatically running 'ssh-add %s'.", privKeyGuess))
+	ui.Message("If your SSH key has a passphrase, you will be prompted for it.")
+	ui.Message("")
+
+	if err := sshagent.Add(ui, privKeyGuess); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/helper/sshagent/sshagent.go
+++ b/helper/sshagent/sshagent.go
@@ -1,0 +1,69 @@
+// Helpers for interacting with the local SSH Agent
+package sshagent
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"reflect"
+
+	execHelper "github.com/hashicorp/otto/helper/exec"
+	"github.com/hashicorp/otto/ui"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// HasKey determines if a given public key (provided as a string with the
+// contents of a public key file), is loaded into the local SSH Agent.
+func HasKey(publicKey string) (bool, error) {
+	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
+	if err != nil {
+		return false, fmt.Errorf("Error parsing provided public key: %s", err)
+	}
+
+	agentKeys, err := ListKeys()
+	if err != nil {
+		return false, err
+	}
+
+	for _, agentKey := range agentKeys {
+		if reflect.DeepEqual(agentKey.Marshal(), pk.Marshal()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ListKeys connects to the local SSH Agent and lists all the public keys
+// loaded into it. It returns user friendly error message when it has trouble.
+func ListKeys() ([]*agent.Key, error) {
+	sshAuthSock := os.Getenv("SSH_AUTH_SOCK")
+	if sshAuthSock == "" {
+		return nil, fmt.Errorf(
+			"The SSH_AUTH_SOCK environment variable is not set, which normally\n" +
+				"means that no SSH Agent is running.")
+	}
+
+	conn, err := net.Dial("unix", sshAuthSock)
+	if err != nil {
+		return nil, fmt.Errorf("Error connecting to agent: %s", err)
+	}
+	defer conn.Close()
+
+	agent := agent.NewClient(conn)
+	loadedKeys, err := agent.List()
+	if err != nil {
+		return nil, fmt.Errorf("Error listing keys: %s", err)
+	}
+	return loadedKeys, err
+}
+
+// Add takes the path of a private key and runs ssh-add locally to add it to
+// the agent. It needs a Ui to be able to interact with the user for the
+// password prompt.
+func Add(ui ui.Ui, privateKeyPath string) error {
+	cmd := exec.Command("ssh-add", privateKeyPath)
+	return execHelper.Run(ui, cmd)
+}

--- a/helper/terraform/infrastructure.go
+++ b/helper/terraform/infrastructure.go
@@ -25,6 +25,10 @@ type Infrastructure struct {
 	// for nice helpers for implementing this function.
 	CredsFunc func(*infrastructure.Context) (map[string]string, error)
 
+	// VerifyCreds is a function that verifies credentials are in good
+	// working order.
+	VerifyCredsFunc func(*infrastructure.Context) error
+
 	// Bindata is the bindata.Data structure where assets can be found
 	// for compilation. The data for the various flavors is expected to
 	// live in "data/#{flavor}"
@@ -36,6 +40,10 @@ type Infrastructure struct {
 
 func (i *Infrastructure) Creds(ctx *infrastructure.Context) (map[string]string, error) {
 	return i.CredsFunc(ctx)
+}
+
+func (i *Infrastructure) VerifyCreds(ctx *infrastructure.Context) error {
+	return i.VerifyCredsFunc(ctx)
 }
 
 func (i *Infrastructure) Execute(ctx *infrastructure.Context) error {

--- a/infrastructure/infrastructure.go
+++ b/infrastructure/infrastructure.go
@@ -15,6 +15,12 @@ type Infrastructure interface {
 	// handle encrypting, storing, and retrieving the credentials.
 	Creds(*Context) (map[string]string, error)
 
+	// VerifyCreds is called with the result of either prompting or
+	// retrieving cached credentials. This gives Infrastructure
+	// implementations a chance to check that credentials are good before
+	// continuing to perform any operations.
+	VerifyCreds(*Context) error
+
 	Execute(*Context) error
 	Compile(*Context) (*CompileResult, error)
 	Flavors() []string

--- a/infrastructure/mock.go
+++ b/infrastructure/mock.go
@@ -12,6 +12,10 @@ func (m *Mock) Creds(ctx *Context) (map[string]string, error) {
 	return nil, nil
 }
 
+func (m *Mock) VerifyCreds(ctx *Context) error {
+	return nil
+}
+
 func (m *Mock) Execute(ctx *Context) error {
 	return nil
 }

--- a/otto/core.go
+++ b/otto/core.go
@@ -687,6 +687,13 @@ func (c *Core) creds(
 
 	// Set the credentials
 	infraCtx.InfraCreds = creds
+
+	// Let the infrastructure do whatever it likes to verify that the credentials
+	// are good, so we can fail fast in case there's a problem.
+	if err := infra.VerifyCreds(infraCtx); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This adds a new VerifyCreds step to the Infrastructure interface that
Core executes just after it fetches creds (either by asking the user or
by loading them from the cache). Infrastructure implementers can do
whatever they like in VerifyCreds in order to ensure that the
loaded credentials are good or still good. If not, a nice up-front error
message can be produced before any work is attempted.

The initial use-case for VerifyCreds is to ensure that the SSH key
provided by the user for AWS infrastructure is loaded into the local SSH
agent.

If we don't find the SSH key in the agent, we do a simple heuristic
(remove ".pub") to see if we find a private key on disk. If so, we
attempt to run ssh-add to load the key for us the user.
