### PR TITLE
appfile: fix issue marshalling multiple deps

### DIFF
--- a/appfile/compile_test.go
+++ b/appfile/compile_test.go
@@ -44,6 +44,12 @@ func TestCompile(t *testing.T) {
 		},
 
 		{
+			"compile-multi-dep",
+			testCompileMultiDepStr,
+			false,
+		},
+
+		{
 			"compile-invalid",
 			"",
 			true,
@@ -358,4 +364,15 @@ Dep Graph:
 bar
 foo
   bar
+`
+
+const testCompileMultiDepStr = `
+Compiled Appfile: %s
+
+Dep Graph:
+bar
+baz
+foo
+  bar
+  baz
 `

--- a/appfile/test-fixtures/compile-multi-dep/Appfile
+++ b/appfile/test-fixtures/compile-multi-dep/Appfile
@@ -1,0 +1,18 @@
+application {
+    name = "foo"
+    type = "bar"
+
+    dependency {
+        source = "./childone"
+    }
+    dependency {
+        source = "./childtwo"
+    }
+}
+
+project {
+    name = "foo"
+    infrastructure = "aws"
+}
+
+infrastructure "aws" {}

--- a/appfile/test-fixtures/compile-multi-dep/childone/Appfile
+++ b/appfile/test-fixtures/compile-multi-dep/childone/Appfile
@@ -1,0 +1,11 @@
+application {
+    name = "bar"
+    type = "bar"
+}
+
+project {
+    name = "foo"
+    infrastructure = "aws"
+}
+
+infrastructure "aws" {}

--- a/appfile/test-fixtures/compile-multi-dep/childtwo/Appfile
+++ b/appfile/test-fixtures/compile-multi-dep/childtwo/Appfile
@@ -1,0 +1,11 @@
+application {
+    name = "baz"
+    type = "baz"
+}
+
+project {
+    name = "foo"
+    infrastructure = "aws"
+}
+
+infrastructure "aws" {}


### PR DESCRIPTION
The JSON representation of the graph had a single object to represent
the set of edges - this meant that multiple edges with the same source
would clobber each other.

Change to a list of objects (one per edge) to avoid this collision.

fixes #72