### PR TITLE
Updating base Vagrant box for development

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ source /etc/profile.d/gopath.sh
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/ubuntu-12.04"
+  config.vm.box = "bento/ubuntu-12.04"
   config.vm.hostname = "otto"
 
   config.vm.provision "shell", inline: $script, privileged: false


### PR DESCRIPTION
- It seems that the "chef/*" boxes have been renamed under the "bento"
organization in Atlas.  If the user does not have an existing version of
the box `vagrant up` will fail.

Fixes #101 