### PR TITLE
Making consul installation more idempotent

### DIFF
--- a/builtin/foundation/consul/data/common/app-build/main.sh.tpl
+++ b/builtin/foundation/consul/data/common/app-build/main.sh.tpl
@@ -31,7 +31,7 @@ EOF
     oe sudo mv /tmp/consul_flags /etc/service/consul
 
     # Setup Consul service and start it
-    oe sudo mv ${dir}/upstart.conf /etc/init/consul.conf
+    oe sudo cp ${dir}/upstart.conf /etc/init/consul.conf
 
     # Setup DNS
     ol "Installing dnsmasq for Consul..."


### PR DESCRIPTION
- Currently if you do an `otto dev destroy` followed by a
`otto dev` without a `otto compile` step inbetween it will
fail to properly install consul as a service again due to
the move of the upstart file.

Fixes #111