### PR TITLE
app/ruby: Detect gem deps for apt-get

### DIFF
--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -115,6 +115,7 @@ gem_deps() {
 
 cd /vagrant
 gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
+gem_deps mysql2 "libmysqlclient-dev"
 gem_deps pg "libpq-dev"
 
 ol "Installing Bundler..."

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -82,7 +82,7 @@ oe sudo apt-get install -y bzr git mercurial build-essential \
   nodejs \
   ruby$RUBY_VERSION ruby$RUBY_VERSION-dev
 
-ol "Configuring Ruby..."
+ol "Configuring Ruby environment..."
 echo 'export GEM_HOME=$HOME/.gem\nexport PATH=$HOME/.gem/bin:$PATH' >> $HOME/.ruby_env
 echo 'source $HOME/.ruby_env' >> $HOME/.bashrc
 source $HOME/.ruby_env

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -103,24 +103,29 @@ has_gem() {
   return 1
 }
 
-gem_deps() {
-  gem_name=$1
-  apt_deps=$2
+gem_deps_queue=()
+
+detect_gem_deps() {
+  gem_name=$1; apt_deps=$2
 
   if has_gem $gem_name; then
-    ol "Installing dependencies for the $gem_name gem..."
-    oe sudo apt-get install -y $apt_deps
+    ol "Detected the $gem_name gem..."
+    gem_deps_queue+=($apt_deps)
   fi
 }
 
 cd /vagrant
-gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
-gem_deps capybara-webkit "libqt4-dev"
-gem_deps mysql2 "libmysqlclient-dev"
-gem_deps nokogiri "zlib1g-dev"
-gem_deps pg "libpq-dev"
-gem_deps rmagick "libmagickwand-dev"
-gem_deps sqlite3 "libsqlite3-dev"
+detect_gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
+detect_gem_deps capybara-webkit "libqt4-dev"
+detect_gem_deps mysql2 "libmysqlclient-dev"
+detect_gem_deps nokogiri "zlib1g-dev"
+detect_gem_deps pg "libpq-dev"
+detect_gem_deps rmagick "libmagickwand-dev"
+detect_gem_deps sqlite3 "libsqlite3-dev"
+if [ -n "$gem_deps_queue" ]; then
+  ol "Installing native gem system dependencies..."
+  oe sudo apt-get install -y "${gem_deps_queue[@]}"
+fi
 
 ol "Installing Bundler..."
 oe gem install bundler --no-document

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -78,7 +78,7 @@ export RUBY_VERSION="{{ ruby_version }}"
 ol "Installing Ruby ${RUBY_VERSION} and supporting packages..."
 export DEBIAN_FRONTEND=noninteractive
 oe sudo apt-get install -y bzr git mercurial build-essential \
-  zlib1g-dev software-properties-common \
+  software-properties-common \
   nodejs \
   ruby$RUBY_VERSION ruby$RUBY_VERSION-dev
 
@@ -116,6 +116,7 @@ gem_deps() {
 cd /vagrant
 gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
 gem_deps mysql2 "libmysqlclient-dev"
+gem_deps nokogiri "zlib1g-dev"
 gem_deps pg "libpq-dev"
 gem_deps rmagick "libmagickwand-dev"
 gem_deps sqlite3 "libsqlite3-dev"

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -115,6 +115,7 @@ gem_deps() {
 
 cd /vagrant
 gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
+gem_deps capybara-webkit "libqt4-dev"
 gem_deps mysql2 "libmysqlclient-dev"
 gem_deps nokogiri "zlib1g-dev"
 gem_deps pg "libpq-dev"

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -118,6 +118,7 @@ gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
 gem_deps mysql2 "libmysqlclient-dev"
 gem_deps pg "libpq-dev"
 gem_deps rmagick "libmagickwand-dev"
+gem_deps sqlite3 "libsqlite3-dev"
 
 ol "Installing Bundler..."
 oe gem install bundler --no-document

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -117,6 +117,7 @@ cd /vagrant
 gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
 gem_deps mysql2 "libmysqlclient-dev"
 gem_deps pg "libpq-dev"
+gem_deps rmagick "libmagickwand-dev"
 
 ol "Installing Bundler..."
 oe gem install bundler --no-document


### PR DESCRIPTION
Greps for gem names in Gemfile.lock, or Gemfile if a lockfile does not exist.
For each found gem, installs system dependencies for that gem using apt.

This could be optimized in the future to build up a complete list of dependencies to install, and running `apt-get` once.

Alternative to #132
Fixes #104
Fixes #133