### PR TITLE
command: support alternative Appfile name

### DIFF
--- a/command/compile_test.go
+++ b/command/compile_test.go
@@ -58,6 +58,44 @@ func TestCompile_pathFile(t *testing.T) {
 	}
 }
 
+func TestCompile_pathDir(t *testing.T) {
+	ui := new(cli.MockUi)
+	c := &CompileCommand{
+		Meta: Meta{
+			CoreConfig: otto.TestCoreConfig(t),
+			Ui:         ui,
+		},
+	}
+
+	dir := fixtureDir("compile-dir")
+	defer os.Remove(filepath.Join(dir, ".ottoid"))
+	defer testChdir(t, dir)()
+
+	args := []string{"-appfile", "dir"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
+func TestCompile_altFile(t *testing.T) {
+	ui := new(cli.MockUi)
+	c := &CompileCommand{
+		Meta: Meta{
+			CoreConfig: otto.TestCoreConfig(t),
+			Ui:         ui,
+		},
+	}
+
+	dir := fixtureDir("compile-alt")
+	defer os.Remove(filepath.Join(dir, ".ottoid"))
+	defer testChdir(t, dir)()
+
+	args := []string{}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
 func testChdir(t *testing.T, dir string) func() {
 	wd, err := os.Getwd()
 	if err != nil {

--- a/command/meta.go
+++ b/command/meta.go
@@ -36,6 +36,12 @@ const (
 	DefaultDataDir = "otto-data"
 )
 
+var (
+	// AltAppfiles is the list of alternative names for an Appfile that Otto can
+	// detect and load automatically
+	AltAppfiles = []string{"appfile.hcl"}
+)
+
 // FlagSetFlags is an enum to define what flags are present in the
 // default FlagSet returned by Meta.FlagSet
 type FlagSetFlags uint

--- a/command/test-fixtures/compile-alt/appfile.hcl
+++ b/command/test-fixtures/compile-alt/appfile.hcl
@@ -1,0 +1,13 @@
+application {
+    name = "test"
+    type = "test"
+}
+
+project {
+    name = "test"
+    infrastructure = "test"
+}
+
+infrastructure "test" {
+    flavor = "test"
+}

--- a/command/test-fixtures/compile-dir/dir/Appfile
+++ b/command/test-fixtures/compile-dir/dir/Appfile
@@ -1,0 +1,13 @@
+application {
+    name = "test"
+    type = "test"
+}
+
+project {
+    name = "test"
+    infrastructure = "test"
+}
+
+infrastructure "test" {
+    flavor = "test"
+}


### PR DESCRIPTION
Adds logic so Otto will automatically recognize appfile.hcl in addition
to Appfile.

Fixes #61