### PR TITLE
Fix undefined: path.

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -218,7 +218,7 @@ func findAppfile(flag string) (string, error) {
 		}
 
 		if fi.IsDir() {
-			return findAppfileInDir(path), nil
+			return findAppfileInDir(flag), nil
 		} else {
 			return flag, nil
 		}


### PR DESCRIPTION
When running "make dev" getting "command/compile.go:221: undefined: path"
Think flag is the intended variable.