### PR TITLE
app/ruby: Bundle during otto dev

### DIFF
--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -91,6 +91,9 @@ source $HOME/.ruby_env
 ol "Installing Bundler..."
 oe gem install bundler --no-document
 
+ol "Bundling gem dependencies..."
+oe bundle
+
 ol "Configuring Git to use SSH instead of HTTP so we can agent-forward private repo auth..."
 oe git config --global url."git@github.com:".insteadOf "https://github.com/"
 SCRIPT


### PR DESCRIPTION
Does a `bundle ` (install) during `otto dev`. This is semi-dependent on #137, since ideally `otto dev` would not fail due to an error compiling native gems.

Fixes #150