### PR TITLE
Clarify error message when infrastructure type not supported.

### DIFF
--- a/otto/core.go
+++ b/otto/core.go
@@ -827,7 +827,7 @@ func (c *Core) infra() (infrastructure.Infrastructure, *infrastructure.Context, 
 	if !ok {
 		return nil, nil, fmt.Errorf(
 			"infrastructure type not supported: %s",
-			c.appfile.Project.Infrastructure)
+			config.Type)
 	}
 
 	// Start the infrastructure implementation


### PR DESCRIPTION
This output the type not being supported when that is the case.