### PR TITLE
Custom type vagranfile rendering

### DIFF
--- a/builtin/app/custom/customization.go
+++ b/builtin/app/custom/customization.go
@@ -72,6 +72,9 @@ func (c *customizations) compileCustomDeploy(d *schema.FieldData) compile.Compil
 
 func (c *customizations) compileCustomDev(d *schema.FieldData) compile.CompileCallback {
 	return func() error {
+		c.Opts.Bindata.RenderReal(
+			filepath.Join(c.Opts.Ctx.Dir, "dev", "Vagrantfile"),
+			c.Opts.Bindata.Context["dev_vagrant_path"].(string))
 		return c.Opts.Bindata.RenderAsset(
 			filepath.Join(c.Opts.Ctx.Dir, "dev", "vagrantfile_path"),
 			"data/sentinels/vagrant_path.tpl")

--- a/builtin/app/custom/customization.go
+++ b/builtin/app/custom/customization.go
@@ -34,7 +34,8 @@ func (c *customizations) processDeploy(d *schema.FieldData) error {
 }
 
 func (c *customizations) processDev(d *schema.FieldData) error {
-	p, ok := d.GetOk("vagrant")
+	p, ok := d.GetOk("vagrantfile")
+
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
For the custom app type, render Vagrantfile as-is when compiling for development.

[Fixes: #158]