### PR TITLE
adding git to default nodejs Vagrantfile provisioning

### DIFF
--- a/builtin/app/node/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/node/data/common/dev/Vagrantfile.tpl
@@ -84,4 +84,7 @@ oe sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20
 oe sudo update-alternatives --config gcc
 oe sudo update-alternatives --config g++
 
+ol "Installing Git..."
+oe sudo apt-get install -y git
+
 SCRIPT


### PR DESCRIPTION
Per #126 , adding git package install in `nodejs` default `Vagrantfile`