### PR TITLE
app/ruby: Rails w/ Postgres/Sqlite support

### DIFF
--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -41,7 +41,7 @@ Vagrant.configure("2") do |config|
 end
 
 $script_locale = <<SCRIPT
-  oe() { $@ 2>&1 | logger -t otto > /dev/null; }
+  oe() { eval "$@" 2>&1 | logger -t otto > /dev/null; }
   ol() { echo "[otto] $@"; }
 
   ol "Setting locale to en_US.UTF-8..."
@@ -61,7 +61,7 @@ error() {
 trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
 
 # otto-exec: execute command with output logged but not displayed
-oe() { $@ 2>&1 | logger -t otto > /dev/null; }
+oe() { eval "$@" 2>&1 | logger -t otto > /dev/null; }
 
 # otto-log: output a prefixed message
 ol() { echo "[otto] $@"; }

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -121,7 +121,7 @@ detect_gem_deps() {
   gem_name=$1; apt_deps=$2
 
   if has_gem $gem_name; then
-    ol "Detected the $gem_name gem..."
+    ol "Detected the $gem_name gem"
     gem_deps_queue+=($apt_deps)
   fi
 }
@@ -145,6 +145,13 @@ oe gem install bundler --no-document
 
 ol "Bundling gem dependencies..."
 oe bundle
+
+{% if app_type == "rails" %}
+  ol "Detected Rails application"
+
+  ol "Preparing the database..."
+  oe "bundle exec rake db:setup || bundle exec rake db:migrate"
+{% endif %}
 
 ol "Configuring Git to use SSH instead of HTTP so we can agent-forward private repo auth..."
 oe git config --global url."git@github.com:".insteadOf "https://github.com/"

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -29,6 +29,9 @@ Vagrant.configure("2") do |config|
   {{ fragment|read }}
   {% endfor %}
 
+  # Set locale to en_US.UTF-8
+  config.vm.provision "shell", inline: $script_locale
+
   # Install Ruby build environment
   config.vm.provision "shell", inline: $script_ruby, privileged: false
 
@@ -36,6 +39,15 @@ Vagrant.configure("2") do |config|
     o.vm.box = "parallels/ubuntu-12.04"
   end
 end
+
+$script_locale = <<SCRIPT
+  oe() { $@ 2>&1 | logger -t otto > /dev/null; }
+  ol() { echo "[otto] $@"; }
+
+  ol "Setting locale to en_US.UTF-8..."
+  oe locale-gen en_US.UTF-8
+  oe update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+SCRIPT
 
 $script_ruby = <<SCRIPT
 set -o nounset -o errexit -o pipefail -o errtrace

--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -149,6 +149,13 @@ oe bundle
 {% if app_type == "rails" %}
   ol "Detected Rails application"
 
+  if has_gem pg; then
+    ol "Detected the pg gem, installing PostgreSQL..."
+    . /etc/default/locale
+    oe sudo apt-get install -y postgresql-9.1
+    oe sudo -u postgres createuser --superuser vagrant
+  fi
+
   ol "Preparing the database..."
   oe "bundle exec rake db:setup || bundle exec rake db:migrate"
 {% endif %}

--- a/builtin/app/ruby/tuple.go
+++ b/builtin/app/ruby/tuple.go
@@ -7,6 +7,7 @@ import (
 // Tuples is the list of tuples that this built-in app implementation knows
 // that it can support.
 var Tuples = app.TupleSlice([]app.Tuple{
+	{"rails", "aws", "simple"},
 	{"ruby", "aws", "simple"},
 	{"ruby", "aws", "vpc-public-private"},
 })

--- a/commands.go
+++ b/commands.go
@@ -35,6 +35,10 @@ var Detectors = []*detect.Detector{
 		File: []string{"*.php", "composer.json"},
 	},
 	&detect.Detector{
+		Type: "rails",
+		File: []string{"config/application.rb"},
+	},
+	&detect.Detector{
 		Type: "ruby",
 		File: []string{"*.rb", "Gemfile", "config.ru"},
 	},

--- a/commands_test.go
+++ b/commands_test.go
@@ -11,12 +11,17 @@ func TestDetectors_ordering(t *testing.T) {
 
 	// PHP projects frequently have a package.json
 	if !isBefore(types, "php", "node") {
-		t.Errorf("node is before php")
+		t.Errorf("php is not before node")
+	}
+
+	// Rails projects are also Ruby projects
+	if !isBefore(types, "rails", "ruby") {
+		t.Errorf("ruby is not before rails")
 	}
 
 	// Ruby projects frequently have a package.json
 	if !isBefore(types, "ruby", "node") {
-		t.Errorf("node is before ruby")
+		t.Errorf("ruby is not before node")
 	}
 }
 

--- a/helper/compile/app.go
+++ b/helper/compile/app.go
@@ -59,6 +59,8 @@ func App(opts *AppOptions) (*app.CompileResult, error) {
 		data.Context = make(map[string]interface{})
 		opts.Bindata = data
 	}
+
+	data.Context["app_type"] = ctx.Appfile.Application.Type
 	data.Context["name"] = ctx.Appfile.Application.Name
 	data.Context["dev_fragments"] = ctx.DevDepFragments
 	data.Context["dev_ip_address"] = ctx.DevIPAddress


### PR DESCRIPTION
This adds a Rails type to the detectors, and exposes this as app_type to the templates. If Rails is detected, we prepare/migrate the database. If the pg gem is present, we install PostgreSQL 9.1. Sqlite is also implicitly supported.

This does not add MySQL support.