### PR TITLE
Install libxml dependancy for libxml-ruby

### DIFF
--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -122,6 +122,7 @@ detect_gem_deps nokogiri "zlib1g-dev"
 detect_gem_deps pg "libpq-dev"
 detect_gem_deps rmagick "libmagickwand-dev"
 detect_gem_deps sqlite3 "libsqlite3-dev"
+detect_gem_deps libxml-ruby "libxml-dev"
 
 if [ -n "${gem_deps_queue-}" ]; then
   ol "Installing native gem system dependencies..."


### PR DESCRIPTION
My app was failing to build because `libxml-ruby` required the `libxml-dev` package. As per #133 , this seems to be the preferred way to require packages for now?