### PR TITLE
helper/vagrant: Add halt action

### DIFF
--- a/helper/vagrant/dev.go
+++ b/helper/vagrant/dev.go
@@ -49,6 +49,12 @@ func Dev(opts *DevOptions) *router.Router {
 				HelpText:     strings.TrimSpace(actionDestroyHelp),
 			},
 
+			"halt": &router.SimpleAction{
+				ExecuteFunc:  opts.actionHalt,
+				SynopsisText: actionHaltSyn,
+				HelpText:     strings.TrimSpace(actionHaltHelp),
+			},
+
 			"ssh": &router.SimpleAction{
 				ExecuteFunc:  opts.actionSSH,
 				SynopsisText: actionSSHSyn,
@@ -100,6 +106,24 @@ func (opts *DevOptions) actionDestroy(rctx router.Context) error {
 	}
 
 	ctx.Ui.Header("[green]Development environment has been destroyed!")
+	return nil
+}
+
+func (opts *DevOptions) actionHalt(rctx router.Context) error {
+	ctx := rctx.(*app.Context)
+	project := Project(&ctx.Shared)
+	if err := project.InstallIfNeeded(); err != nil {
+		return err
+	}
+
+	ctx.Ui.Header("Halting the the local development environment...")
+
+	if err := opts.vagrant(ctx).Execute("halt"); err != nil {
+		return err
+	}
+
+	ctx.Ui.Header("[green]Development environment halted!")
+
 	return nil
 }
 
@@ -205,6 +229,7 @@ const (
 	actionAddressSyn = "Shows the address to reach the development environment"
 	actionUpSyn      = "Starts the development environment"
 	actionDestroySyn = "Destroy the development environment"
+	actionHaltSyn    = "Halts the development environment"
 	actionSSHSyn     = "SSH into the development environment"
 	actionVagrantSyn = "Run arbitrary Vagrant commands"
 )
@@ -232,6 +257,16 @@ Usage: otto dev destroy
   Any data that was put onto the development environment will be deleted,
   except for your own project's code (the directory and any subdirectories
   where the Appfile exists).
+
+`
+
+const actionHaltHelp = `
+Usage: otto dev halt
+
+  Halts the development environment.
+
+  This command will stop the development environment. The environment can then
+  be started again with 'otto dev'.
 
 `
 


### PR DESCRIPTION
Adds `otto dev halt` as a shortcut for `otto dev vagrant halt`.

With existing dev env:

```
$ otto dev halt
==> Halting the the local development environment...
==> default: Attempting graceful shutdown of VM...

==> Development environment halted!
```

Without having run `otto dev`:

```
$ otto dev halt
==> Halting the the local development environment...
==> default: VM not created. Moving on...

==> Development environment halted!
```

Help output:

```
$ otto dev help
The available subcommands are shown below along with a
brief description of what that command does. For more complete
help, call the `help` subcommand with the name of the specific
subcommand you want help for, such as `help foo`.

The subcommand '(default)' is the blank subcommand. For this
you don't specify any additional text.

          ssh   SSH into the development environment
         halt   Halts the development environment
         help   This help
      address   Shows the address to reach the development environment
      destroy   Destroy the development environment
      vagrant   Run arbitrary Vagrant commands
    (default)   Starts the development environment
```

Fixes #171