### PR TITLE
app/go: install Godep automatically

### DIFF
--- a/builtin/app/go/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/go/data/common/dev/Vagrantfile.tpl
@@ -81,6 +81,11 @@ ol "Installing VCSs for go get..."
 oe sudo apt-get update -y
 oe sudo apt-get install -y git bzr mercurial
 
+{% if godeps %}
+ol "Installing Godep..."
+oe sudo -H -u vagrant bash -l -c 'go get github.com/tools/godep'
+{% endif %}
+
 ol "Configuring Go to use SSH instead of HTTP..."
 git config --global url."git@github.com:".insteadOf "https://github.com/"
 SCRIPT

--- a/builtin/app/go/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/go/data/common/dev/Vagrantfile.tpl
@@ -74,8 +74,8 @@ fstype=$(find /opt/gopath -mindepth 0 -maxdepth 0 -type d -printf "%F")
 find /opt/gopath -fstype ${fstype} -print0 | xargs -0 -n 100 chown vagrant:vagrant
 
 ol "Setting up PATH..."
-echo 'export PATH=/opt/gopath/bin:/usr/local/go/bin:$PATH' >> /home/vagrant/.bashrc
-echo 'export GOPATH=/opt/gopath' >> /home/vagrant/.bashrc
+echo 'export PATH=/opt/gopath/bin:/usr/local/go/bin:$PATH' >> /home/vagrant/.profile
+echo 'export GOPATH=/opt/gopath' >> /home/vagrant/.profile
 
 ol "Installing VCSs for go get..."
 oe sudo apt-get update -y


### PR DESCRIPTION
If Godep is detected, we now install Godep automatically. 

This is just the first step of what we can do with this. This should ultimately affect how we build the software (by using `godep go build`).