### PR TITLE
app/ruby: Change apt deps for mysql2 gem

### DIFF
--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -117,7 +117,7 @@ detect_gem_deps() {
 cd /vagrant
 detect_gem_deps curb "libcurl3 libcurl3-gnutls libcurl4-openssl-dev"
 detect_gem_deps capybara-webkit "libqt4-dev"
-detect_gem_deps mysql2 "libmysqlclient-dev"
+detect_gem_deps mysql2 "libmysqld-dev"
 detect_gem_deps nokogiri "zlib1g-dev"
 detect_gem_deps pg "libpq-dev"
 detect_gem_deps rmagick "libmagickwand-dev"


### PR DESCRIPTION
I think mysql2 needs the libmysqld-dev instead of the libmysqlclient-dev.

https://groups.google.com/forum/#!topic/rubyonrails-talk/plbfXkcoISY