### PR TITLE
Adjusting appfile loading to allow for proper type merging

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -212,7 +212,7 @@ func loadAppfile(flagAppfile string) (*appfile.File, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	return app, app.Path, nil
+	return app, filepath.Dir(app.Path), nil
 }
 
 // findAppfile returns the path to an existing Appfile by checking the optional

--- a/command/compile_test.go
+++ b/command/compile_test.go
@@ -41,6 +41,59 @@ func TestCompile(t *testing.T) {
 	}
 }
 
+func TestCompile_noExplicitType(t *testing.T) {
+	core := otto.TestCoreConfig(t)
+	infra := otto.TestInfra(t, "aws", core)
+	appImpl := otto.TestApp(t, app.Tuple{"test-detection-merge", "aws", "simple"}, core)
+	appImpl.CompileFunc = func(ctx *app.Context) (*app.CompileResult, error) {
+		if ctx.Application == nil {
+			t.Fatal("application unexpectedly nil")
+		}
+		if ctx.Application.Name != "compile-no-explicit-type" {
+			t.Fatalf("expected: compile-no-explicit-type; got: %s", ctx.Application.Name)
+		}
+		if ctx.Application.Type != "test-detection-merge" {
+			t.Fatalf("expected: test-detection-merge; got: %s", ctx.Application.Type)
+		}
+		return nil, nil
+	}
+	foundImpl := otto.TestFoundation(
+		t, foundation.Tuple{"consul", "aws", "simple"}, core)
+	ui := new(cli.MockUi)
+	detectors := []*detect.Detector{
+		&detect.Detector{
+			Type: "test-detection-merge",
+			File: []string{"test-file"},
+		},
+	}
+	c := &CompileCommand{
+		Meta: Meta{
+			CoreConfig: core,
+			Ui:         ui,
+		},
+		Detectors: detectors,
+	}
+
+	dir := fixtureDir("compile-detection")
+	defer os.Remove(filepath.Join(dir, ".ottoid"))
+	defer testChdir(t, dir)()
+
+	args := []string{}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	if !infra.CompileCalled {
+		t.Fatal("Compile should be called")
+	}
+	if !appImpl.CompileCalled {
+		t.Fatal("Compile should be called")
+	}
+	if !foundImpl.CompileCalled {
+		t.Fatal("Foundation should be called")
+	}
+}
+
 func TestCompile_noAppFile(t *testing.T) {
 	core := otto.TestCoreConfig(t)
 	infra := otto.TestInfra(t, "aws", core)

--- a/command/test-fixtures/compile-detection/Appfile
+++ b/command/test-fixtures/compile-detection/Appfile
@@ -1,0 +1,3 @@
+application {
+  name = "compile-no-explicit-type"
+}


### PR DESCRIPTION
@mitchellh Fixes #192 is still not functional due to an issue with the parameters being passed into the default method. 

- Adjusting the output of the loadAppfile method to properly
return Appfile's dir instead of path

