### PR TITLE
Customizing node installation to allow for preprocessing

### DIFF
--- a/builtin/app/node/data/aws-simple/build/build-node.sh.tpl
+++ b/builtin/app/node/data/aws-simple/build/build-node.sh.tpl
@@ -81,6 +81,6 @@ server {
 NGINXCONF
 
 ol "Running npm..."
-sudo -u otto-app -i /bin/bash -lc "cd /srv/otto-app && npm install --production"
+sudo -u otto-app -i /bin/bash -lc "cd /srv/otto-app && npm install && npm prune --production"
 
 ol "...done!"


### PR DESCRIPTION
Fixes #214 by making the "devDependencies" available during the various npm script targets prior to cleaning them up with the npm prune --production.  