### PR TITLE
docs: fix common typos

### DIFF
--- a/website/source/docs/apps/custom/customization.html.md
+++ b/website/source/docs/apps/custom/customization.html.md
@@ -4,13 +4,13 @@ page_title: "Customization - Custom App Type"
 sidebar_current: "docs-custom-customization"
 description: |-
   This page documents the customizations
-  that are availabile to change the behavior of custom applications with Otto.
+  that are available to change the behavior of custom applications with Otto.
 ---
 
 # Customization
 
 This page documents the [customizations](/docs/appfile/customization.html)
-that are availabile to change the behavior of the "custom" application
+that are available to change the behavior of the "custom" application
 type with Otto.
 
 ## Type: "dev"
@@ -23,7 +23,7 @@ customization "dev" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `vagrantfile` (string) - Path to a Vagrantfile to use for development.
     If this isn't specified, `otto dev` will not work for this application.
@@ -38,7 +38,7 @@ customization "dev-dep" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `vagrantfile` (string) - Path to a Vagrantfile to use as a fragment
     that is embedded in other application's Vagrantfiles when this application
@@ -54,7 +54,7 @@ customization "build" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `packer` (string) - Path to a Packer template to execute.
 
@@ -68,7 +68,7 @@ customization "deploy" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `terraform` (string) - Path to a Terraform module (directory) to use
     for deployment.

--- a/website/source/docs/apps/docker-external/customization.html.md
+++ b/website/source/docs/apps/docker-external/customization.html.md
@@ -4,13 +4,13 @@ page_title: "Customization - Docker (External) App Type"
 sidebar_current: "docs-docker-customization"
 description: |-
   This page documents the [customizations](/docs/appfile/customization.html)
-  that are availabile to change the behavior of Docker applications with Otto.
+  that are available to change the behavior of Docker applications with Otto.
 ---
 
 # Customization
 
 This page documents the [customizations](/docs/appfile/customization.html)
-that are availabile to change the behavior of Docker applications with Otto.
+that are available to change the behavior of Docker applications with Otto.
 
 ## Type: "docker"
 
@@ -22,7 +22,7 @@ customization "docker" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `image` (string) - The Docker image to run (along with any tags).
     This will defaulit to the application name.

--- a/website/source/docs/apps/go/customization.html.md
+++ b/website/source/docs/apps/go/customization.html.md
@@ -4,13 +4,13 @@ page_title: "Customization - Go App Type"
 sidebar_current: "docs-go-customization"
 description: |-
   This page documents the customizations
-  that are availabile to change the behavior of Go applications with Otto.
+  that are available to change the behavior of Go applications with Otto.
 ---
 
 # Customization
 
 This page documents the [customizations](/docs/appfile/customization.html)
-that are availabile to change the behavior of Go applications with Otto.
+that are available to change the behavior of Go applications with Otto.
 
 ## Type: "go"
 
@@ -22,7 +22,7 @@ customization "go" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `go_version` (string) - The Go version to install for development
     and for building the application for deployment. This defaulits to 1.5.1.

--- a/website/source/docs/apps/node/customization.html.md
+++ b/website/source/docs/apps/node/customization.html.md
@@ -4,13 +4,13 @@ page_title: "Customization - Node.js App Type"
 sidebar_current: "docs-node-customization"
 description: |-
   This page documents the [Customizations](/docs/appfile/customization.html)
-  that are availabile to change the behavior of Node.js applications with Otto.
+  that are available to change the behavior of Node.js applications with Otto.
 ---
 
 # Customization
 
 This page documents the [customizations](/docs/appfile/customization.html)
-that are availabile to change the behavior of Node.js applications with Otto.
+that are available to change the behavior of Node.js applications with Otto.
 
 ## Type: "node"
 
@@ -22,7 +22,7 @@ customization "node" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `node_version` (string) - The Node.js version to install
     and deployment. This defaults to 4.1.0.

--- a/website/source/docs/apps/php/customization.html.md
+++ b/website/source/docs/apps/php/customization.html.md
@@ -4,7 +4,7 @@ page_title: "Customization - PHP App Type"
 sidebar_current: "docs-php-customization"
 description: |-
   This page documents the [Customizations](/docs/appfile/customization.html)
-  that are availabile to change the behavior of PHP applications with Otto.
+  that are available to change the behavior of PHP applications with Otto.
 ---
 
 # Customization

--- a/website/source/docs/apps/ruby/customization.html.md
+++ b/website/source/docs/apps/ruby/customization.html.md
@@ -4,13 +4,13 @@ page_title: "Customization - Ruby App Type"
 sidebar_current: "docs-ruby-customization"
 description: |-
   This page documents the [Customizations](/docs/appfile/customization.html)
-  that are availabile to change the behavior of Ruby applications with Otto.
+  that are available to change the behavior of Ruby applications with Otto.
 ---
 
 # Customization
 
 This page documents the [customizations](/docs/appfile/customization.html)
-that are availabile to change the behavior of Ruby applications with Otto.
+that are available to change the behavior of Ruby applications with Otto.
 
 ## Type: "ruby"
 
@@ -22,7 +22,7 @@ customization "ruby" {
 }
 ```
 
-Availabile options:
+Available options:
 
   * `ruby_version` (string) - The Ruby version to install for development
     and deployment. This defaults to 2.2. Note that for Ruby 1.9.3, you

--- a/website/source/docs/infra/index.html.md
+++ b/website/source/docs/infra/index.html.md
@@ -12,7 +12,7 @@ description: |-
 The infrastructure type in the [Appfile](/docs/concepts/appfile.html)
 tells Otto what kind of infrastructure you'd like to use to deploy your
 application. Otto uses this information to create a base infrastructure, to
-build your application for that infrastructrue, and finally to deploy your
+build your application for that infrastructure, and finally to deploy your
 application into that infrastructure.
 
 This section documents the infrastructure types that Otto supports by default


### PR DESCRIPTION
- Replace all occurrences of '[aA]vailabile' with '[aA]vailable]'
- Replace occurrence of 'infrastrctrue' with 'infrastructure'