### PR TITLE
Update _docs.scss

### DIFF
--- a/website/source/assets/stylesheets/_docs.scss
+++ b/website/source/assets/stylesheets/_docs.scss
@@ -219,11 +219,10 @@ body.layout-intro{
 		color: $orange;
 		border-bottom: 1px solid $orange;
 		@include transition(all 300ms ease-in);
-
+		text-decoration: none;
 		&:hover{
 			color: $black;
 			border-bottom: 2px solid $black;
-			text-decoration: none;
 			@include transition(all 300ms ease-in);
 		}
 	}


### PR DESCRIPTION
Fix double underline(border + a underline) for links when:
- drag start
- click to open link in new tab

Firefox: http://joxi.ru/krD9O7VILzakmp.jpg
Chrome: http://joxi.ru/xAee189H6xwyAy.jpg