### PR TITLE
Add imagemagick dependency for paperclip

### DIFF
--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -135,6 +135,7 @@ detect_gem_deps pg "libpq-dev"
 detect_gem_deps rmagick "libmagickwand-dev"
 detect_gem_deps sqlite3 "libsqlite3-dev"
 detect_gem_deps libxml-ruby "libxml-dev"
+detect_gem_deps paperclip "imagemagick"
 
 if [ -n "${gem_deps_queue-}" ]; then
   ol "Installing native gem system dependencies..."


### PR DESCRIPTION
The [paperclip](https://github.com/thoughtbot/paperclip) gem relies on the `imagemagick` package for it's image processing and not on `rmagick`.  Pull request #133 suggests adding submitting pull requests to handle package specific binaries.  Is this still the case or have I missed a way to easily configure specific packages?