### PR TITLE
command/help 

### DIFF
--- a/command/help.go
+++ b/command/help.go
@@ -1,0 +1,36 @@
+package command
+
+import (
+	"strings"
+)
+
+// HelpCommand is not a real command. It just shows help output for
+// people expecting `otto help` to work.
+type HelpCommand struct {
+	Meta
+}
+
+func (c *HelpCommand) Run(args []string) int {
+	c.Ui.Error(strings.TrimSpace(helpOutput))
+	return 1
+}
+
+func (c *HelpCommand) Synopsis() string {
+	return "Not a real command."
+}
+
+func (c *HelpCommand) Help() string {
+	return "Not a real command."
+}
+
+const helpOutput = `
+Otto doesn't use "otto help" for subcommand help!
+
+For a list of all available top level subcommands, run "otto -h".
+
+For individual commands use the "-h" flag to get help. For example:
+"otto status -h" will show you how to use the status command.
+
+For commands that take subcommands such as "dev", use the "help" subcommand
+to get a full listing of availabile subcommands. For example: "otto dev help".
+`

--- a/commands.go
+++ b/commands.go
@@ -24,6 +24,7 @@ import (
 
 // Commands is the mapping of all the available Otto commands.
 var Commands map[string]cli.CommandFactory
+var CommandsInclude []string
 
 var Detectors = []*detect.Detector{
 	&detect.Detector{
@@ -91,6 +92,16 @@ func init() {
 		Ui: Ui,
 	}
 
+	CommandsInclude = []string{
+		"compile",
+		"build",
+		"deploy",
+		"dev",
+		"infra",
+		"status",
+		"version",
+	}
+
 	Commands = map[string]cli.CommandFactory{
 		"compile": func() (cli.Command, error) {
 			return &command.CompileCommand{
@@ -136,6 +147,12 @@ func init() {
 				Version:           Version,
 				VersionPrerelease: VersionPrerelease,
 				CheckFunc:         commandVersionCheck,
+			}, nil
+		},
+
+		"help": func() (cli.Command, error) {
+			return &command.HelpCommand{
+				Meta: meta,
 			}, nil
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -117,9 +117,10 @@ func wrappedMain() int {
 	}
 
 	cli := &cli.CLI{
-		Args:       args,
-		Commands:   Commands,
-		HelpFunc:   cli.BasicHelpFunc("otto"),
+		Args:     args,
+		Commands: Commands,
+		HelpFunc: cli.FilteredHelpFunc(
+			CommandsInclude, cli.BasicHelpFunc("otto")),
 		HelpWriter: os.Stdout,
 	}
 


### PR DESCRIPTION
Fixes #74 

This adds a stub `otto help` command that shows how to get help for Otto commands (since we don't use that subcommand). This is to help people expecting this to work. 

We filter the `otto` output so that the help subcommand isn't shown. It is just there in case someone types it.