### PR TITLE
Apps can return/access "compile version"

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -64,6 +64,11 @@ type App interface {
 type Context struct {
 	context.Shared
 
+	// CompileResult is the result of the compilation. This is set on
+	// all calls except Compile to be the data from the compilation. This
+	// can be used to check compile versions, for example.
+	CompileResult *CompileResult
+
 	// Action is the sub-action to take when being executed.
 	//
 	// ActionArgs is the list of arguments for this action.
@@ -130,6 +135,10 @@ func (c *Context) UI() ui.Ui {
 
 // CompileResult is the structure containing compilation result values.
 type CompileResult struct {
+	// Version is the version of the compiled result. This is purely metadata:
+	// the app itself should use this to detect certain behaviors on run.
+	Version uint32
+
 	// FoundationConfig is the configuration for the various foundational
 	// elements of Otto.
 	FoundationConfig foundation.Config
@@ -138,4 +147,9 @@ type CompileResult struct {
 	// should be added to other Vagrantfiles when this application is
 	// used as a dependency.
 	DevDepFragmentPath string
+
+	// FoundationResults are the compilation results of the foundations.
+	//
+	// This is populated by Otto core and any set value here will be ignored.
+	FoundationResults []*foundation.CompileResult
 }

--- a/app/app.go
+++ b/app/app.go
@@ -137,19 +137,19 @@ func (c *Context) UI() ui.Ui {
 type CompileResult struct {
 	// Version is the version of the compiled result. This is purely metadata:
 	// the app itself should use this to detect certain behaviors on run.
-	Version uint32
+	Version uint32 `json:"version"`
 
 	// FoundationConfig is the configuration for the various foundational
 	// elements of Otto.
-	FoundationConfig foundation.Config
+	FoundationConfig foundation.Config `json:"foundation_config"`
 
 	// DevDepFragmentPath is the path to the Vagrantfile fragment that
 	// should be added to other Vagrantfiles when this application is
 	// used as a dependency.
-	DevDepFragmentPath string
+	DevDepFragmentPath string `json:"dev_dep_fragment_path"`
 
 	// FoundationResults are the compilation results of the foundations.
 	//
 	// This is populated by Otto core and any set value here will be ignored.
-	FoundationResults []*foundation.CompileResult
+	FoundationResults map[string]*foundation.CompileResult `json:"foundation_results"`
 }

--- a/infrastructure/infrastructure.go
+++ b/infrastructure/infrastructure.go
@@ -65,5 +65,4 @@ func (c *Context) UI() ui.Ui {
 }
 
 // CompileResult is the structure containing compilation result values.
-type CompileResult struct {
-}
+type CompileResult struct{}

--- a/otto/compile.go
+++ b/otto/compile.go
@@ -1,7 +1,12 @@
 package otto
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
 	"github.com/hashicorp/otto/app"
+	"github.com/hashicorp/otto/foundation"
 	"github.com/hashicorp/otto/infrastructure"
 )
 
@@ -12,14 +17,61 @@ import (
 // compilation.
 type CompileMetadata struct {
 	// App is the result of compiling the main application
-	App *app.CompileResult
+	App *app.CompileResult `json:"app"`
 
 	// Deps are the results of compiling the dependencies, keyed by their
 	// unique Otto ID. If you want the tree structure then use the Appfile
 	// itself to search the dependency tree, then the ID of that dep
 	// to key into this map.
-	AppDeps map[string]*app.CompileResult
+	AppDeps map[string]*app.CompileResult `json:"app_deps"`
 
 	// Infra is the result of compiling the infrastructure for this application
-	Infra *infrastructure.CompileResult
+	Infra *infrastructure.CompileResult `json:"infra"`
+
+	// Foundations is the listing of top-level foundation compilation results.
+	Foundations map[string]*foundation.CompileResult `json:"foundations"`
+}
+
+func (c *Core) resetCompileMetadata() {
+	c.metadataCache = nil
+}
+
+func (c *Core) compileMetadata() (*CompileMetadata, error) {
+	if c.metadataCache != nil {
+		return c.metadataCache, nil
+	}
+
+	f, err := os.Open(filepath.Join(c.compileDir, "metadata.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+	defer f.Close()
+
+	var result CompileMetadata
+	dec := json.NewDecoder(f)
+	if err := dec.Decode(&result); err != nil {
+		return nil, err
+	}
+
+	c.metadataCache = &result
+	return &result, nil
+}
+
+func (c *Core) saveCompileMetadata(md *CompileMetadata) error {
+	if err := os.MkdirAll(c.compileDir, 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(filepath.Join(c.compileDir, "metadata.json"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	return enc.Encode(md)
 }

--- a/otto/compile.go
+++ b/otto/compile.go
@@ -1,0 +1,25 @@
+package otto
+
+import (
+	"github.com/hashicorp/otto/app"
+	"github.com/hashicorp/otto/infrastructure"
+)
+
+// CompileMetadata is the stored metadata about a successful compilation.
+//
+// Failures during compilation result in no metadata at all being stored.
+// This metadata can be used to access various information about the resulting
+// compilation.
+type CompileMetadata struct {
+	// App is the result of compiling the main application
+	App *app.CompileResult
+
+	// Deps are the results of compiling the dependencies, keyed by their
+	// unique Otto ID. If you want the tree structure then use the Appfile
+	// itself to search the dependency tree, then the ID of that dep
+	// to key into this map.
+	AppDeps map[string]*app.CompileResult
+
+	// Infra is the result of compiling the infrastructure for this application
+	Infra *infrastructure.CompileResult
+}

--- a/otto/core.go
+++ b/otto/core.go
@@ -34,6 +34,8 @@ type Core struct {
 	localDir        string
 	compileDir      string
 	ui              ui.Ui
+
+	metadataCache *CompileMetadata
 }
 
 // CoreConfig is configuration for creating a new core with NewCore.
@@ -93,6 +95,10 @@ func NewCore(c *CoreConfig) (*Core, error) {
 
 // Compile takes the Appfile and compiles all the resulting data.
 func (c *Core) Compile() error {
+	// md stores the metadata about the compilation. This is only written
+	// on a successful compile.
+	var md CompileMetadata
+
 	// Get the infra implementation for this
 	infra, infraCtx, err := c.infra()
 	if err != nil {
@@ -112,29 +118,38 @@ func (c *Core) Compile() error {
 		return err
 	}
 
+	// Reset the metadata cache so we don't have that
+	c.resetCompileMetadata()
+
 	// Compile the infrastructure for our application
 	log.Printf("[INFO] running infra compile...")
 	c.ui.Message("Compiling infra...")
-	if _, err := infra.Compile(infraCtx); err != nil {
+	infraResult, err := infra.Compile(infraCtx)
+	if err != nil {
 		return err
 	}
+	md.Infra = infraResult
 
 	// Compile the foundation (not tied to any app). This compilation
 	// of the foundation is used for `otto infra` to set everything up.
 	log.Printf("[INFO] running foundation compilations")
+	md.Foundations = make(map[string]*foundation.CompileResult, len(foundations))
 	for i, f := range foundations {
 		ctx := foundationCtxs[i]
 		c.ui.Message(fmt.Sprintf(
 			"Compiling foundation: %s", ctx.Tuple.Type))
-		if _, err := f.Compile(ctx); err != nil {
+		result, err := f.Compile(ctx)
+		if err != nil {
 			return err
 		}
+
+		md.Foundations[ctx.Tuple.Type] = result
 	}
 
 	// Walk through the dependencies and compile all of them.
 	// We have to compile every dependency for dev building.
-	var resultLock sync.Mutex
-	results := make([]*app.CompileResult, 0, len(c.appfileCompiled.Graph.Vertices()))
+	var mdLock sync.Mutex
+	md.AppDeps = make(map[string]*app.CompileResult)
 	err = c.walk(func(app app.App, ctx *app.Context, root bool) error {
 		if !root {
 			c.ui.Header(fmt.Sprintf(
@@ -149,15 +164,15 @@ func (c *Core) Compile() error {
 		if root {
 			// We grab the lock just in case although if we're the
 			// root this should be serialized.
-			resultLock.Lock()
-			ctx.DevDepFragments = make([]string, 0, len(results))
-			for _, result := range results {
+			mdLock.Lock()
+			ctx.DevDepFragments = make([]string, 0, len(md.AppDeps))
+			for _, result := range md.AppDeps {
 				if result.DevDepFragmentPath != "" {
 					ctx.DevDepFragments = append(
 						ctx.DevDepFragments, result.DevDepFragmentPath)
 				}
 			}
-			resultLock.Unlock()
+			mdLock.Unlock()
 		}
 
 		// Compile!
@@ -187,15 +202,24 @@ func (c *Core) Compile() error {
 			}
 		}
 
-		// Store the compilation result for later
-		resultLock.Lock()
-		defer resultLock.Unlock()
-		results = append(results, result)
+		// Store the compilation result in the metadata
+		mdLock.Lock()
+		defer mdLock.Unlock()
+
+		if root {
+			md.App = result
+		} else {
+			md.AppDeps[ctx.Appfile.ID] = result
+		}
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
-	return err
+	// We had no compilation errors! Let's save the metadata
+	return c.saveCompileMetadata(&md)
 }
 
 func (c *Core) walk(f func(app.App, *app.Context, bool) error) error {
@@ -722,6 +746,9 @@ func (c *Core) executeApp(opts *ExecuteOpts) error {
 }
 
 func (c *Core) appContext(f *appfile.File) (*app.Context, error) {
+	// Whether or not this is the root Appfile
+	root := f.ID == c.appfile.ID
+
 	// We need the configuration for the active infrastructure
 	// so that we can build the tuple below
 	config := f.ActiveInfrastructure()
@@ -744,9 +771,9 @@ func (c *Core) appContext(f *appfile.File) (*app.Context, error) {
 	// it goes directly into "app" or it is a dependency and goes into
 	// a dep folder.
 	outputDir := filepath.Join(c.compileDir, "app")
-	if id := f.ID; id != c.appfile.ID {
+	if !root {
 		outputDir = filepath.Join(
-			c.compileDir, fmt.Sprintf("dep-%s", id))
+			c.compileDir, fmt.Sprintf("dep-%s", f.ID))
 	}
 
 	// The cache directory for this app
@@ -776,13 +803,29 @@ func (c *Core) appContext(f *appfile.File) (*app.Context, error) {
 			"Error retrieving dev IP address: %s", err)
 	}
 
+	// Get the metadata
+	var compileResult *app.CompileResult
+	md, err := c.compileMetadata()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error loading compilation metadata: %s", err)
+	}
+	if md != nil {
+		if root {
+			compileResult = md.App
+		} else {
+			compileResult = md.AppDeps[f.ID]
+		}
+	}
+
 	return &app.Context{
-		Dir:          outputDir,
-		CacheDir:     cacheDir,
-		LocalDir:     c.localDir,
-		Tuple:        tuple,
-		Application:  f.Application,
-		DevIPAddress: ip.String(),
+		CompileResult: compileResult,
+		Dir:           outputDir,
+		CacheDir:      cacheDir,
+		LocalDir:      c.localDir,
+		Tuple:         tuple,
+		Application:   f.Application,
+		DevIPAddress:  ip.String(),
 		Shared: context.Shared{
 			Appfile:        f,
 			FoundationDirs: foundationDirs,

--- a/otto/core_test.go
+++ b/otto/core_test.go
@@ -1,0 +1,45 @@
+package otto
+
+import (
+	"testing"
+
+	"github.com/hashicorp/otto/app"
+)
+
+func TestCoreDev_compileMetadata(t *testing.T) {
+	// Make a core that returns a fixed app
+	coreConfig := TestCoreConfig(t)
+	coreConfig.Appfile = TestAppfile(t, testPath("basic", "Appfile"))
+	appMock := TestApp(t, TestAppTuple, coreConfig)
+	core := testCore(t, coreConfig)
+
+	// Configure the app to return a specific version in the metadata
+	appMock.CompileResult = &app.CompileResult{Version: 12}
+
+	// Compile!
+	if err := core.Compile(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Rebuild all the core so we have a fresh core
+	core = testCore(t, coreConfig)
+
+	// Run dev
+	if err := core.Dev(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// The context should have the right version
+	if appMock.DevContext.CompileResult.Version != 12 {
+		t.Fatalf("bad: %#v", appMock.DevContext.CompileResult)
+	}
+}
+
+func testCore(t *testing.T, config *CoreConfig) *Core {
+	core, err := NewCore(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return core
+}

--- a/otto/otto_test.go
+++ b/otto/otto_test.go
@@ -1,0 +1,13 @@
+package otto
+
+import (
+	"path/filepath"
+)
+
+func testPath(path ...string) string {
+	args := make([]string, 1, len(path)+1)
+	args[0] = "./test-fixtures"
+	args = append(args, path...)
+
+	return filepath.Join(args...)
+}

--- a/otto/test-fixtures/basic/.ottoid
+++ b/otto/test-fixtures/basic/.ottoid
@@ -1,0 +1,13 @@
+bbdc7d8e-00d9-6942-06a3-7212ae461d2d
+
+DO NOT MODIFY OR DELETE THIS FILE!
+
+This file should be checked in to version control. Do not ignore this file.
+
+The first line is a unique UUID that represents the Appfile in this directory.
+This UUID is used globally across your projects to identify this specific
+Appfile. This UUID allows you to modify the name of an application, or have
+duplicate application names without conflicting.
+
+If you delete this file, then deploys may duplicate this application since
+Otto will be unable to tell that the application is deployed.

--- a/otto/testing.go
+++ b/otto/testing.go
@@ -1,23 +1,93 @@
 package otto
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/otto/app"
+	"github.com/hashicorp/otto/appfile"
+	"github.com/hashicorp/otto/appfile/detect"
 	"github.com/hashicorp/otto/foundation"
 	"github.com/hashicorp/otto/infrastructure"
 	"github.com/hashicorp/otto/ui"
 )
 
+// TestAppTuple is a basic app tuple that can be used for testing and
+// has all fields set to "test".
+var TestAppTuple = app.Tuple{"test", "test", "test"}
+
+// TestAppfile returns a compiled appfile for the given path. This uses
+// defaults for detectors and such so it is up to you to use a fairly
+// complete Appfile.
+func TestAppfile(t *testing.T, path string) *appfile.Compiled {
+	def, err := appfile.Default(filepath.Dir(path), &detect.Config{
+		Detectors: []*detect.Detector{
+			&detect.Detector{
+				Type: "test",
+				File: []string{"Appfile"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Default type should be "test"
+	def.Infrastructure[0].Type = "test"
+	def.Infrastructure[0].Flavor = "test"
+	def.Infrastructure[0].Foundations = nil
+
+	// Parse the raw file
+	f, err := appfile.ParseFile(path)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Merge
+	if err := def.Merge(f); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	f = def
+
+	// Create a temporary directory for the compilation data. We don't
+	// delete this now in case we're using any of that data, but the
+	// temp dir should get cleaned up by the system at some point.
+	td, err := ioutil.TempDir("", "otto")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Compile it!
+	result, err := appfile.Compile(f, &appfile.CompileOpts{
+		Dir: td,
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return result
+}
+
 // TestCoreConfig returns a CoreConfig that can be used for testing.
 func TestCoreConfig(t *testing.T) *CoreConfig {
+	// Temporary directory for data
+	td, err := ioutil.TempDir("", "otto")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Basic config
 	config := &CoreConfig{
-		Ui: new(ui.Mock),
+		DataDir:    filepath.Join(td, "data"),
+		LocalDir:   filepath.Join(td, "local"),
+		CompileDir: filepath.Join(td, "compile"),
+		Ui:         new(ui.Mock),
 	}
 
 	// Add some default mock implementations. These can be overwritten easily
 	TestInfra(t, "test", config)
-	TestApp(t, app.Tuple{"test", "test", "test"}, config)
+	TestApp(t, TestAppTuple, config)
 
 	return config
 }


### PR DESCRIPTION
This adds a field to `CompileResult` that apps can use to store an arbitrary version. This version can be accessed in the context in the future to do version-specific behavior. 

This should let us change the app implementation but understand compilation directories from a previous version.