### PR TITLE
Reset Vagrant check to 1.7.4

### DIFF
--- a/helper/vagrant/vagrant.go
+++ b/helper/vagrant/vagrant.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	vagrantMinVersion = version.Must(version.NewVersion("1.7.99"))
+	vagrantMinVersion = version.Must(version.NewVersion("1.7.4"))
 )
 
 // Project returns the hashitools Project for this.


### PR DESCRIPTION
This pull request resets the Vagrant check version to 1.7.4.  I was having issues running otto from the master branch locally - the check of "1.7.99" failed.  (Unless there is a better way to override that setting.)