### PR TITLE
Plugin streams (stdout, stderr) are connected

### DIFF
--- a/command/plugin_manager.go
+++ b/command/plugin_manager.go
@@ -69,8 +69,10 @@ func (p *Plugin) Load() error {
 
 	// Create the plugin client to communicate with the process
 	pluginClient := plugin.NewClient(&plugin.ClientConfig{
-		Cmd:     exec.Command(path, p.Args...),
-		Managed: true,
+		Cmd:        exec.Command(path, p.Args...),
+		Managed:    true,
+		SyncStdout: os.Stdout,
+		SyncStderr: os.Stderr,
 	})
 
 	// Request the client

--- a/helper/vagrant/ssh.go
+++ b/helper/vagrant/ssh.go
@@ -29,7 +29,7 @@ func (c *SSHCache) Exec(cacheOkay bool) error {
 	// If we have the cache file, use that
 	if _, err := os.Stat(c.Path); err == nil {
 		log.Printf("[DEBUG] ssh command: ssh -F " + c.Path + " default")
-		cmd := exec.Command("ssh", "-F", c.Path, "default")
+		cmd := exec.Command("ssh", "-t", "-t", "-F", c.Path, "default")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -63,8 +64,20 @@ type ClientConfig struct {
 	StartTimeout time.Duration
 
 	// If non-nil, then the stderr of the client will be written to here
-	// (as well as the log).
+	// (as well as the log). This is the original os.Stderr of the subprocess.
+	// This isn't the output of synced stderr.
 	Stderr io.Writer
+
+	// SyncStdin, SyncStdout, SyncStderr can be set to override the
+	// respective os.Std* values in the plugin. Care should be taken to
+	// avoid races here. If these are nil, then this will automatically be
+	// hooked up to os.Stdin, Stdout, and Stderr, respectively.
+	//
+	// If the default values (nil) are used, then this package will not
+	// sync any of these streams.
+	SyncStdin  io.Reader
+	SyncStdout io.Writer
+	SyncStderr io.Writer
 }
 
 // This makes sure all the managed subprocesses are killed and properly
@@ -113,6 +126,16 @@ func NewClient(config *ClientConfig) (c *Client) {
 		config.Stderr = ioutil.Discard
 	}
 
+	if config.SyncStdin == nil {
+		config.SyncStdin = bytes.NewReader(nil)
+	}
+	if config.SyncStdout == nil {
+		config.SyncStdout = ioutil.Discard
+	}
+	if config.SyncStderr == nil {
+		config.SyncStderr = ioutil.Discard
+	}
+
 	c = &Client{config: config}
 	if config.Managed {
 		managedClients = append(managedClients, c)
@@ -139,6 +162,17 @@ func (c *Client) Client() (*pluginrpc.Client, error) {
 
 	c.client, err = pluginrpc.Dial(addr.Network(), addr.String())
 	if err != nil {
+		return nil, err
+	}
+
+	// Begin the stream syncing so that stdin, out, err work properly
+	err = c.client.SyncStreams(
+		c.config.SyncStdin,
+		c.config.SyncStdout,
+		c.config.SyncStderr)
+	if err != nil {
+		c.client.Close()
+		c.client = nil
 		return nil, err
 	}
 

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -68,14 +67,13 @@ type ClientConfig struct {
 	// This isn't the output of synced stderr.
 	Stderr io.Writer
 
-	// SyncStdin, SyncStdout, SyncStderr can be set to override the
+	// SyncStdout, SyncStderr can be set to override the
 	// respective os.Std* values in the plugin. Care should be taken to
 	// avoid races here. If these are nil, then this will automatically be
 	// hooked up to os.Stdin, Stdout, and Stderr, respectively.
 	//
 	// If the default values (nil) are used, then this package will not
 	// sync any of these streams.
-	SyncStdin  io.Reader
 	SyncStdout io.Writer
 	SyncStderr io.Writer
 }
@@ -126,9 +124,6 @@ func NewClient(config *ClientConfig) (c *Client) {
 		config.Stderr = ioutil.Discard
 	}
 
-	if config.SyncStdin == nil {
-		config.SyncStdin = bytes.NewReader(nil)
-	}
 	if config.SyncStdout == nil {
 		config.SyncStdout = ioutil.Discard
 	}
@@ -167,7 +162,6 @@ func (c *Client) Client() (*pluginrpc.Client, error) {
 
 	// Begin the stream syncing so that stdin, out, err work properly
 	err = c.client.SyncStreams(
-		c.config.SyncStdin,
 		c.config.SyncStdout,
 		c.config.SyncStderr)
 	if err != nil {

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -105,6 +105,11 @@ func Serve(opts *ServeOpts) {
 		}
 	}()
 
+	// Set our new stdin, out, err
+	os.Stdin = stdin_r
+	os.Stdout = stdout_w
+	os.Stderr = stderr_w
+
 	// Serve
 	server.Accept(listener)
 }

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -50,11 +50,6 @@ func Serve(opts *ServeOpts) {
 
 	// Create our new stdout, stderr files. These will override our built-in
 	// stdout/stderr so that it works across the stream boundary.
-	stdin_r, stdin_w, err := os.Pipe()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error preparing Otto plugin: %s\n", err)
-		os.Exit(1)
-	}
 	stdout_r, stdout_w, err := os.Pipe()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error preparing Otto plugin: %s\n", err)
@@ -77,7 +72,6 @@ func Serve(opts *ServeOpts) {
 	// Create the RPC server to dispense
 	server := &pluginrpc.Server{
 		AppFunc: opts.AppFunc,
-		Stdin:   stdin_w,
 		Stdout:  stdout_r,
 		Stderr:  stderr_r,
 	}
@@ -105,8 +99,7 @@ func Serve(opts *ServeOpts) {
 		}
 	}()
 
-	// Set our new stdin, out, err
-	os.Stdin = stdin_r
+	// Set our new out, err
 	os.Stdout = stdout_w
 	os.Stderr = stderr_w
 

--- a/rpc/app_test.go
+++ b/rpc/app_test.go
@@ -15,7 +15,8 @@ func TestApp_impl(t *testing.T) {
 }
 
 func TestApp_meta(t *testing.T) {
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	appMock := server.AppFunc().(*app.Mock)
@@ -45,7 +46,8 @@ func TestApp_meta(t *testing.T) {
 }
 
 func TestApp_compile(t *testing.T) {
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	appMock := server.AppFunc().(*app.Mock)
@@ -71,7 +73,8 @@ func TestApp_compile(t *testing.T) {
 }
 
 func TestApp_compileUi(t *testing.T) {
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	appMock := server.AppFunc().(*app.Mock)
@@ -103,7 +106,8 @@ func TestApp_compileUi(t *testing.T) {
 }
 
 func TestApp_build(t *testing.T) {
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	appMock := server.AppFunc().(*app.Mock)
@@ -122,7 +126,8 @@ func TestApp_build(t *testing.T) {
 }
 
 func TestApp_deploy(t *testing.T) {
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	appMock := server.AppFunc().(*app.Mock)
@@ -141,7 +146,8 @@ func TestApp_deploy(t *testing.T) {
 }
 
 func TestApp_dev(t *testing.T) {
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	appMock := server.AppFunc().(*app.Mock)
@@ -160,7 +166,8 @@ func TestApp_dev(t *testing.T) {
 }
 
 func TestApp_devDep(t *testing.T) {
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	appMock := server.AppFunc().(*app.Mock)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -1,7 +1,10 @@
 package rpc
 
 import (
+	"bytes"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/otto/app"
 )
@@ -11,6 +14,9 @@ func TestClient_App(t *testing.T) {
 
 	c := new(app.Mock)
 	server := &Server{AppFunc: testAppFixed(c)}
+	streams := testNewStreams(t, server)
+	defer streams.Close()
+
 	go server.ServeConn(serverConn)
 
 	client, err := NewClient(clientConn)
@@ -31,5 +37,37 @@ func TestClient_App(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("bad: %#v", err)
+	}
+}
+
+func TestClient_syncStreams(t *testing.T) {
+	client, _, streams := testNewClientServer(t)
+
+	// Start the data copying
+	var stdout_out, stderr_out, stdin_out bytes.Buffer
+	stdout := bytes.NewBufferString("stdouttest")
+	stderr := bytes.NewBufferString("stderrtest")
+	stdin := bytes.NewBufferString("stdintest")
+	go client.SyncStreams(stdin, &stdout_out, &stderr_out)
+	go io.Copy(&stdin_out, streams.Stdin)
+	go io.Copy(streams.Stdout, stdout)
+	go io.Copy(streams.Stderr, stderr)
+
+	// Unfortunately I can't think of a better way to make sure all the
+	// copies above go through so let's just exit.
+	time.Sleep(100 * time.Millisecond)
+
+	// Close everything, and lets test the result
+	client.Close()
+	streams.Close()
+
+	if v := stdin_out.String(); v != "stdintest" {
+		t.Fatalf("bad: %s", v)
+	}
+	if v := stdout_out.String(); v != "stdouttest" {
+		t.Fatalf("bad: %s", v)
+	}
+	if v := stderr_out.String(); v != "stderrtest" {
+		t.Fatalf("bad: %s", v)
 	}
 }

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -44,12 +44,10 @@ func TestClient_syncStreams(t *testing.T) {
 	client, _, streams := testNewClientServer(t)
 
 	// Start the data copying
-	var stdout_out, stderr_out, stdin_out bytes.Buffer
+	var stdout_out, stderr_out bytes.Buffer
 	stdout := bytes.NewBufferString("stdouttest")
 	stderr := bytes.NewBufferString("stderrtest")
-	stdin := bytes.NewBufferString("stdintest")
-	go client.SyncStreams(stdin, &stdout_out, &stderr_out)
-	go io.Copy(&stdin_out, streams.Stdin)
+	go client.SyncStreams(&stdout_out, &stderr_out)
 	go io.Copy(streams.Stdout, stdout)
 	go io.Copy(streams.Stderr, stderr)
 
@@ -61,9 +59,6 @@ func TestClient_syncStreams(t *testing.T) {
 	client.Close()
 	streams.Close()
 
-	if v := stdin_out.String(); v != "stdintest" {
-		t.Fatalf("bad: %s", v)
-	}
 	if v := stdout_out.String(); v != "stdouttest" {
 		t.Fatalf("bad: %s", v)
 	}

--- a/rpc/directory_test.go
+++ b/rpc/directory_test.go
@@ -22,7 +22,8 @@ func TestDirectory(t *testing.T) {
 	defer os.RemoveAll(td)
 
 	// Create the actual plugin client/server
-	client, server := testNewClientServer(t)
+	client, server, streams := testNewClientServer(t)
+	defer streams.Close()
 	defer client.Close()
 
 	// Build a context that points to our bolt directory backend

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -65,16 +65,13 @@ func testNewClientServer(t *testing.T) (*Client, *Server, *testStreams) {
 }
 
 func testNewStreams(t *testing.T, s *Server) *testStreams {
-	stdin_r, stdin_w := io.Pipe()
 	stdout_r, stdout_w := io.Pipe()
 	stderr_r, stderr_w := io.Pipe()
 
-	s.Stdin = stdin_w
 	s.Stdout = stdout_r
 	s.Stderr = stderr_r
 
 	return &testStreams{
-		Stdin:  stdin_r,
 		Stdout: stdout_w,
 		Stderr: stderr_w,
 	}
@@ -87,13 +84,11 @@ func testAppFixed(c app.App) AppFunc {
 }
 
 type testStreams struct {
-	Stdin  io.ReadCloser
 	Stdout io.WriteCloser
 	Stderr io.WriteCloser
 }
 
 func (s *testStreams) Close() error {
-	s.Stdin.Close()
 	s.Stdout.Close()
 	s.Stderr.Close()
 	return nil

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -15,11 +15,10 @@ import (
 type Server struct {
 	AppFunc AppFunc
 
-	// Stdin, Stdout, Stderr are what this server will use instead of the
+	// Stdout, Stderr are what this server will use instead of the
 	// normal stdin/out/err. This is because due to the multi-process nature
 	// of our plugin system, we can't use the normal process values so we
 	// make our own custom one we pipe across.
-	Stdin  io.Writer
 	Stdout io.Reader
 	Stderr io.Reader
 }
@@ -63,7 +62,7 @@ func (s *Server) ServeConn(conn io.ReadWriteCloser) {
 	}
 
 	// Connect the stdstreams (in, out, err)
-	stdstream := make([]net.Conn, 3)
+	stdstream := make([]net.Conn, 2)
 	for i, _ := range stdstream {
 		stdstream[i], err = mux.Accept()
 		if err != nil {
@@ -74,9 +73,8 @@ func (s *Server) ServeConn(conn io.ReadWriteCloser) {
 	}
 
 	// Copy std streams out to the proper place
-	go copyStream("stdin", s.Stdin, stdstream[0])
-	go copyStream("stdout", stdstream[1], s.Stdout)
-	go copyStream("stderr", stdstream[2], s.Stderr)
+	go copyStream("stdout", stdstream[0], s.Stdout)
+	go copyStream("stderr", stdstream[1], s.Stderr)
 
 	// Create the broker and start it up
 	broker := newMuxBroker(mux)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -14,6 +14,14 @@ import (
 // implementations over net/rpc.
 type Server struct {
 	AppFunc AppFunc
+
+	// Stdin, Stdout, Stderr are what this server will use instead of the
+	// normal stdin/out/err. This is because due to the multi-process nature
+	// of our plugin system, we can't use the normal process values so we
+	// make our own custom one we pipe across.
+	Stdin  io.Writer
+	Stdout io.Reader
+	Stderr io.Reader
 }
 
 // AppFunc creates app.App when they're requested from the server.
@@ -53,6 +61,22 @@ func (s *Server) ServeConn(conn io.ReadWriteCloser) {
 		log.Printf("[ERR] plugin: %s", err)
 		return
 	}
+
+	// Connect the stdstreams (in, out, err)
+	stdstream := make([]net.Conn, 3)
+	for i, _ := range stdstream {
+		stdstream[i], err = mux.Accept()
+		if err != nil {
+			mux.Close()
+			log.Printf("[ERR] plugin: accepting stream %d: %s", i, err)
+			return
+		}
+	}
+
+	// Copy std streams out to the proper place
+	go copyStream("stdin", s.Stdin, stdstream[0])
+	go copyStream("stdout", stdstream[1], s.Stdout)
+	go copyStream("stderr", stdstream[2], s.Stderr)
 
 	// Create the broker and start it up
 	broker := newMuxBroker(mux)

--- a/rpc/stream.go
+++ b/rpc/stream.go
@@ -1,0 +1,18 @@
+package rpc
+
+import (
+	"io"
+	"log"
+)
+
+func copyStream(name string, dst io.Writer, src io.Reader) {
+	if src == nil {
+		panic(name + ": src is nil")
+	}
+	if dst == nil {
+		panic(name + ": dst is nil")
+	}
+	if _, err := io.Copy(dst, src); err != nil && err != io.EOF {
+		log.Printf("[ERR] plugin: stream copy '%s' error: %s", name, err)
+	}
+}


### PR DESCRIPTION
This makes it so that `os.Stdout` and `os.Stderr` work in plugins: if you write to them, they go to stdout/stderr on the host process. Plugins _should_ use `Ui` objects to communicate with the outside world but some situations such as `otto dev ssh` which subprocess to `ssh` require direct access to stdout/stderr/stdin.

It turns out we already hooked up stdin just fine with plugins, but stdout/stderr were being dropped. This makes it so that stdout/stderr are now streamed across yamux streams and mirrored directly onto the host version.