### PR TITLE
Fixed printing of help strings (missing trailing newlines)

### DIFF
--- a/helper/terraform/deploy.go
+++ b/helper/terraform/deploy.go
@@ -46,17 +46,17 @@ func Deploy(opts *DeployOptions) *router.Router {
 			"": &router.SimpleAction{
 				ExecuteFunc:  opts.actionDeploy,
 				SynopsisText: actionDeploySyn,
-				HelpText:     strings.TrimSpace(actionDeployHelp),
+				HelpText:     actionDeployHelp,
 			},
 			"destroy": &router.SimpleAction{
 				ExecuteFunc:  opts.actionDestroy,
 				SynopsisText: actionDestroySyn,
-				HelpText:     strings.TrimSpace(actionDestroyHelp),
+				HelpText:     actionDestroyHelp,
 			},
 			"info": &router.SimpleAction{
 				ExecuteFunc:  opts.actionInfo,
 				SynopsisText: actionInfoSyn,
-				HelpText:     strings.TrimSpace(actionInfoHelp),
+				HelpText:     actionInfoHelp,
 			},
 		},
 	}

--- a/helper/terraform/deploy.go
+++ b/helper/terraform/deploy.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/otto/app"
 	"github.com/hashicorp/otto/directory"

--- a/helper/terraform/infrastructure.go
+++ b/helper/terraform/infrastructure.go
@@ -52,17 +52,17 @@ func (i *Infrastructure) Execute(ctx *infrastructure.Context) error {
 			"": &router.SimpleAction{
 				ExecuteFunc:  i.actionApply,
 				SynopsisText: infraApplySyn,
-				HelpText:     strings.TrimSpace(infraApplyHelp),
+				HelpText:     infraApplyHelp,
 			},
 			"destroy": &router.SimpleAction{
 				ExecuteFunc:  i.actionDestroy,
 				SynopsisText: infraDestroySyn,
-				HelpText:     strings.TrimSpace(infraDestroyHelp),
+				HelpText:     infraDestroyHelp,
 			},
 			"info": &router.SimpleAction{
 				ExecuteFunc:  i.actionInfo,
 				SynopsisText: infraInfoSyn,
-				HelpText:     strings.TrimSpace(infraInfoHelp),
+				HelpText:     infraInfoHelp,
 			},
 		},
 	}

--- a/helper/terraform/infrastructure.go
+++ b/helper/terraform/infrastructure.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/otto/directory"
 	"github.com/hashicorp/otto/helper/bindata"

--- a/helper/vagrant/dev.go
+++ b/helper/vagrant/dev.go
@@ -44,43 +44,43 @@ func Dev(opts *DevOptions) *router.Router {
 			"": &router.SimpleAction{
 				ExecuteFunc:  opts.actionUp,
 				SynopsisText: actionUpSyn,
-				HelpText:     strings.TrimSpace(actionUpHelp),
+				HelpText:     actionUpHelp,
 			},
 
 			"address": &router.SimpleAction{
 				ExecuteFunc:  opts.actionAddress,
 				SynopsisText: actionAddressSyn,
-				HelpText:     strings.TrimSpace(actionAddressHelp),
+				HelpText:     actionAddressHelp,
 			},
 
 			"destroy": &router.SimpleAction{
 				ExecuteFunc:  opts.actionDestroy,
 				SynopsisText: actionDestroySyn,
-				HelpText:     strings.TrimSpace(actionDestroyHelp),
+				HelpText:     actionDestroyHelp,
 			},
 
 			"halt": &router.SimpleAction{
 				ExecuteFunc:  opts.actionHalt,
 				SynopsisText: actionHaltSyn,
-				HelpText:     strings.TrimSpace(actionHaltHelp),
+				HelpText:     actionHaltHelp,
 			},
 
 			"layers": &router.SimpleAction{
 				ExecuteFunc:  opts.actionLayers,
 				SynopsisText: actionLayersSyn,
-				HelpText:     strings.TrimSpace(actionLayersHelp),
+				HelpText:     actionLayersHelp,
 			},
 
 			"ssh": &router.SimpleAction{
 				ExecuteFunc:  opts.actionSSH,
 				SynopsisText: actionSSHSyn,
-				HelpText:     strings.TrimSpace(actionSSHHelp),
+				HelpText:     actionSSHHelp,
 			},
 
 			"vagrant": &router.SimpleAction{
 				ExecuteFunc:  opts.actionRaw,
 				SynopsisText: actionVagrantSyn,
-				HelpText:     strings.TrimSpace(actionVagrantHelp),
+				HelpText:     actionVagrantHelp,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #295 by removing `TrimSpace` calls on help strings, so they are printed including newlines and *explicitly defined* whitespace.