### PR TITLE
dead(?) code in config.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,41 +20,7 @@ type Config struct {
 // can be overridden by user configurations.
 var BuiltinConfig Config
 
-// ConfigFile returns the default path to the configuration file.
-//
-// On Unix-like systems this is the ".ottorc" file in the home directory.
-// On Windows, this is the "otto.rc" file in the application data
-// directory.
-func ConfigFile() (string, error) {
-	return configFile()
-}
-
 // ConfigDir returns the configuration directory for Otto.
 func ConfigDir() (string, error) {
 	return configDir()
-}
-
-// LoadConfig loads the CLI configuration from ".ottorc" files.
-func LoadConfig(path string) (*Config, error) {
-	// Read the HCL file and prepare for parsing
-	d, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error reading %s: %s", path, err)
-	}
-
-	// Parse it
-	obj, err := hcl.Parse(string(d))
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error parsing %s: %s", path, err)
-	}
-
-	// Build up the result
-	var result Config
-	if err := hcl.DecodeObject(&result, obj); err != nil {
-		return nil, err
-	}
-
-	return &result, nil
 }


### PR DESCRIPTION
notes:
* this seems important, why is gometalinter telling me:
```
➜  otto git:(lint) gometalinter .
commands.go:133:1:warning: makeShutdownCh is unused (deadcode)
config.go:28:1:warning: ConfigFile is unused (deadcode)
config.go:38:1:warning: LoadConfig is unused (deadcode)
```

if it's not deadcode tho?

test plan:
* sanity check
* tests still pass