### PR TITLE
make CommandsInclude a const

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -17,7 +17,6 @@ import (
 
 // Commands is the mapping of all the available Otto commands.
 var Commands map[string]cli.CommandFactory
-var CommandsInclude []string
 
 // Ui is the cli.Ui used for communicating to the outside world.
 var Ui cli.Ui
@@ -25,6 +24,15 @@ var Ui cli.Ui
 const (
 	ErrorPrefix  = "e:"
 	OutputPrefix = "o:"
+	CommandsInclude = []string{
+    "compile",
+    "build",
+    "deploy",
+    "dev",
+    "infra",
+    "status",
+    "version",
+  }
 )
 
 func init() {
@@ -55,15 +63,7 @@ func init() {
 		PluginMap: pluginmap.Map,
 	}
 
-	CommandsInclude = []string{
-		"compile",
-		"build",
-		"deploy",
-		"dev",
-		"infra",
-		"status",
-		"version",
-	}
+	CommandsInclude = CommandsInclude
 
 	Commands = map[string]cli.CommandFactory{
 		"compile": func() (cli.Command, error) {


### PR DESCRIPTION
test plan:
* regression test commands.go
* verify `gometalinter .` does not return:
"commands.go:20:5:warning: exported var CommandsInclude \
 should have comment or be unexported (golint)"

notes:
* seeing "commands.go:66:2:warning: CommandsInclude \
          assigned and not used (ineffassign)" now :(
* do go linters have problems with tracking im/exports?
  i see CommandsInclude in main.go:

```
cli := &cli.CLI{
  Args:     args,
  Commands: Commandsnds,
  HelpFunc: cli.FilteredHelpFunc(
    CommandsInclude, cli.BasicHelpFunc("otto")),
  HelpWriter: os.Stdout,
}
```