### PR TITLE
Default ruby version to 2.2.0

### DIFF
--- a/builtin/app/ruby/customization.go
+++ b/builtin/app/ruby/customization.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/otto/helper/schema"
 )
 
-const defaultLatestVersion = "2.2"
+const defaultLatestVersion = "2.2.0"
 
 type customizations struct {
 	Opts *compile.AppOptions


### PR DESCRIPTION
Currently the default ruby version points to 2.2 which breaks the "otto dev" when trying to download it as it does not exist here http://cache.ruby-lang.org/pub/ruby/2.2/ This fixes the issue.