### PR TITLE
app/ruby: Fix dependencies for libxml-ruby

### DIFF
--- a/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/ruby/data/common/dev/Vagrantfile.tpl
@@ -54,7 +54,7 @@ detect_gem_deps nokogiri "zlib1g-dev"
 detect_gem_deps pg "libpq-dev"
 detect_gem_deps rmagick "libmagickwand-dev"
 detect_gem_deps sqlite3 "libsqlite3-dev"
-detect_gem_deps libxml-ruby "libxml-dev"
+detect_gem_deps libxml-ruby "libxml2-dev"
 detect_gem_deps paperclip "imagemagick"
 detect_gem_deps poltergeist "phantomjs"
 


### PR DESCRIPTION
``libxml-dev`` is not a valid package. We need to install ``libxml2-dev``.

See #315.