### PR TITLE
appfile: support writing Appfile to HCL

### DIFF
--- a/appfile/file_hcl.go
+++ b/appfile/file_hcl.go
@@ -1,0 +1,281 @@
+package appfile
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/hcl/token"
+)
+
+// HCL converts the Appfile to an HCL AST, allowing printing of the Appfile
+// back to HCL.
+//
+// Note that if you parsed the File from HCL, this will not convert it
+// back to the same HCL. Comments, in particular, won't be preserved.
+func (f *File) HCL() *ast.File {
+	// Convert all the various components into members of the root object
+	items := make([]*ast.ObjectItem, 0, 4+len(f.Imports)+len(f.Customization.Raw))
+	for _, imp := range f.Imports {
+		items = append(items, imp.HCL())
+	}
+	items = append(items, f.Application.HCL())
+	items = append(items, f.Project.HCL())
+	for _, infra := range f.Infrastructure {
+		items = append(items, infra.HCL())
+	}
+	items = append(items, f.Customization.HCL()...)
+
+	// Finalize
+	return &ast.File{
+		Node: &ast.ObjectList{
+			Items: items,
+		},
+	}
+}
+
+func (f *CustomizationSet) HCL() []*ast.ObjectItem {
+	items := make([]*ast.ObjectItem, 0, len(f.Raw))
+	for _, c := range f.Raw {
+		items = append(items, c.HCL())
+	}
+
+	return items
+}
+
+func (f *Customization) HCL() *ast.ObjectItem {
+	items := make([]*ast.ObjectItem, 0, len(f.Config))
+	for k, v := range f.Config {
+		var val ast.Node
+		switch t := v.(type) {
+		case string:
+			val = &ast.LiteralType{
+				Token: token.Token{
+					Type: token.STRING,
+					Text: fmt.Sprintf(`"%s"`, t),
+				},
+			}
+		default:
+			panic(fmt.Sprintf("can't convert to HCL: %T", t))
+		}
+
+		items = append(items, &ast.ObjectItem{
+			Keys: []*ast.ObjectKey{
+				&ast.ObjectKey{
+					Token: token.Token{Type: token.IDENT, Text: k},
+				},
+			},
+			Val: val,
+		})
+	}
+
+	return &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "dependency"},
+			},
+			&ast.ObjectKey{
+				Token: token.Token{
+					Type: token.STRING,
+					Text: fmt.Sprintf(`"%s"`, f.Type),
+				},
+			},
+		},
+		Val: &ast.ObjectType{
+			List: &ast.ObjectList{
+				Items: items,
+			},
+		},
+	}
+}
+
+func (f *Dependency) HCL() *ast.ObjectItem {
+	items := make([]*ast.ObjectItem, 0, 1)
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "source"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Source),
+			},
+		},
+	})
+
+	return &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "dependency"},
+			},
+		},
+		Val: &ast.ObjectType{
+			List: &ast.ObjectList{
+				Items: items,
+			},
+		},
+	}
+}
+
+func (f *Import) HCL() *ast.ObjectItem {
+	return &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "import"},
+			},
+			&ast.ObjectKey{
+				Token: token.Token{
+					Type: token.STRING,
+					Text: fmt.Sprintf(`"%s"`, f.Source),
+				},
+			},
+		},
+		Val: &ast.ObjectType{},
+	}
+}
+
+func (f *Application) HCL() *ast.ObjectItem {
+	items := make([]*ast.ObjectItem, 0, 2+len(f.Dependencies))
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "name"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Name),
+			},
+		},
+	})
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "type"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Type),
+			},
+		},
+	})
+	for _, dep := range f.Dependencies {
+		items = append(items, dep.HCL())
+	}
+
+	return &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "application"},
+			},
+		},
+		Val: &ast.ObjectType{
+			List: &ast.ObjectList{
+				Items: items,
+			},
+		},
+	}
+}
+
+func (f *Project) HCL() *ast.ObjectItem {
+	items := make([]*ast.ObjectItem, 0, 2)
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "name"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Name),
+			},
+		},
+	})
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "infrastructure"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Infrastructure),
+			},
+		},
+	})
+
+	return &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "project"},
+			},
+		},
+		Val: &ast.ObjectType{
+			List: &ast.ObjectList{
+				Items: items,
+			},
+		},
+	}
+}
+
+func (f *Infrastructure) HCL() *ast.ObjectItem {
+	items := make([]*ast.ObjectItem, 0, 3+len(f.Foundations))
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "name"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Name),
+			},
+		},
+	})
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "type"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Type),
+			},
+		},
+	})
+	items = append(items, &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "flavor"},
+			},
+		},
+		Val: &ast.LiteralType{
+			Token: token.Token{
+				Type: token.STRING,
+				Text: fmt.Sprintf(`"%s"`, f.Flavor),
+			},
+		},
+	})
+
+	return &ast.ObjectItem{
+		Keys: []*ast.ObjectKey{
+			&ast.ObjectKey{
+				Token: token.Token{Type: token.IDENT, Text: "infrastructure"},
+			},
+		},
+		Val: &ast.ObjectType{
+			List: &ast.ObjectList{
+				Items: items,
+			},
+		},
+	}
+}

--- a/appfile/file_hcl.go
+++ b/appfile/file_hcl.go
@@ -163,24 +163,26 @@ func (f *Application) HCL() *ast.ObjectItem {
 		},
 		Assign: emptyAssign,
 	})
-	items = append(items, &ast.ObjectItem{
-		Keys: []*ast.ObjectKey{
-			&ast.ObjectKey{
-				Token: token.Token{
-					Type: token.IDENT,
-					Text: "type",
-					Pos:  token.Pos{Line: 2},
+	if f.Type != "" {
+		items = append(items, &ast.ObjectItem{
+			Keys: []*ast.ObjectKey{
+				&ast.ObjectKey{
+					Token: token.Token{
+						Type: token.IDENT,
+						Text: "type",
+						Pos:  token.Pos{Line: 2},
+					},
 				},
 			},
-		},
-		Val: &ast.LiteralType{
-			Token: token.Token{
-				Type: token.STRING,
-				Text: fmt.Sprintf(`"%s"`, f.Type),
+			Val: &ast.LiteralType{
+				Token: token.Token{
+					Type: token.STRING,
+					Text: fmt.Sprintf(`"%s"`, f.Type),
+				},
 			},
-		},
-		Assign: emptyAssign,
-	})
+			Assign: emptyAssign,
+		})
+	}
 	for _, dep := range f.Dependencies {
 		item := dep.HCL()
 		items = append(items, item)

--- a/appfile/file_hcl.go
+++ b/appfile/file_hcl.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/hcl/hcl/token"
 )
 
+var emptyAssign = token.Pos{Line: 1}
+
 // HCL converts the Appfile to an HCL AST, allowing printing of the Appfile
 // back to HCL.
 //
@@ -14,7 +16,7 @@ import (
 // back to the same HCL. Comments, in particular, won't be preserved.
 func (f *File) HCL() *ast.File {
 	// Convert all the various components into members of the root object
-	items := make([]*ast.ObjectItem, 0, 4+len(f.Imports)+len(f.Customization.Raw))
+	items := make([]*ast.ObjectItem, 0, 10+len(f.Imports))
 	for _, imp := range f.Imports {
 		items = append(items, imp.HCL())
 	}
@@ -34,6 +36,10 @@ func (f *File) HCL() *ast.File {
 }
 
 func (f *CustomizationSet) HCL() []*ast.ObjectItem {
+	if f == nil {
+		return nil
+	}
+
 	items := make([]*ast.ObjectItem, 0, len(f.Raw))
 	for _, c := range f.Raw {
 		items = append(items, c.HCL())
@@ -64,7 +70,8 @@ func (f *Customization) HCL() *ast.ObjectItem {
 					Token: token.Token{Type: token.IDENT, Text: k},
 				},
 			},
-			Val: val,
+			Val:    val,
+			Assign: emptyAssign,
 		})
 	}
 
@@ -102,6 +109,7 @@ func (f *Dependency) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Source),
 			},
 		},
+		Assign: emptyAssign,
 	})
 
 	return &ast.ObjectItem{
@@ -140,7 +148,11 @@ func (f *Application) HCL() *ast.ObjectItem {
 	items = append(items, &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "name"},
+				Token: token.Token{
+					Type: token.IDENT,
+					Text: "name",
+					Pos:  token.Pos{Line: 1},
+				},
 			},
 		},
 		Val: &ast.LiteralType{
@@ -149,11 +161,16 @@ func (f *Application) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Name),
 			},
 		},
+		Assign: emptyAssign,
 	})
 	items = append(items, &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "type"},
+				Token: token.Token{
+					Type: token.IDENT,
+					Text: "type",
+					Pos:  token.Pos{Line: 2},
+				},
 			},
 		},
 		Val: &ast.LiteralType{
@@ -162,9 +179,11 @@ func (f *Application) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Type),
 			},
 		},
+		Assign: emptyAssign,
 	})
 	for _, dep := range f.Dependencies {
-		items = append(items, dep.HCL())
+		item := dep.HCL()
+		items = append(items, item)
 	}
 
 	return &ast.ObjectItem{
@@ -186,7 +205,11 @@ func (f *Project) HCL() *ast.ObjectItem {
 	items = append(items, &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "name"},
+				Token: token.Token{
+					Type: token.IDENT,
+					Text: "name",
+					Pos:  token.Pos{Line: 1},
+				},
 			},
 		},
 		Val: &ast.LiteralType{
@@ -195,11 +218,16 @@ func (f *Project) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Name),
 			},
 		},
+		Assign: emptyAssign,
 	})
 	items = append(items, &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "infrastructure"},
+				Token: token.Token{
+					Type: token.IDENT,
+					Text: "infrastructure",
+					Pos:  token.Pos{Line: 2},
+				},
 			},
 		},
 		Val: &ast.LiteralType{
@@ -208,6 +236,7 @@ func (f *Project) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Infrastructure),
 			},
 		},
+		Assign: emptyAssign,
 	})
 
 	return &ast.ObjectItem{
@@ -229,7 +258,11 @@ func (f *Infrastructure) HCL() *ast.ObjectItem {
 	items = append(items, &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "name"},
+				Token: token.Token{
+					Type: token.IDENT,
+					Text: "name",
+					Pos:  token.Pos{Line: 1},
+				},
 			},
 		},
 		Val: &ast.LiteralType{
@@ -238,11 +271,16 @@ func (f *Infrastructure) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Name),
 			},
 		},
+		Assign: emptyAssign,
 	})
 	items = append(items, &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "type"},
+				Token: token.Token{
+					Type: token.IDENT,
+					Text: "type",
+					Pos:  token.Pos{Line: 2},
+				},
 			},
 		},
 		Val: &ast.LiteralType{
@@ -251,11 +289,16 @@ func (f *Infrastructure) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Type),
 			},
 		},
+		Assign: emptyAssign,
 	})
 	items = append(items, &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "flavor"},
+				Token: token.Token{
+					Type: token.IDENT,
+					Text: "flavor",
+					Pos:  token.Pos{Line: 3},
+				},
 			},
 		},
 		Val: &ast.LiteralType{
@@ -264,6 +307,7 @@ func (f *Infrastructure) HCL() *ast.ObjectItem {
 				Text: fmt.Sprintf(`"%s"`, f.Flavor),
 			},
 		},
+		Assign: emptyAssign,
 	})
 
 	return &ast.ObjectItem{

--- a/appfile/file_hcl_test.go
+++ b/appfile/file_hcl_test.go
@@ -1,0 +1,125 @@
+package appfile
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/hcl/printer"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func TestFileHCL(t *testing.T) {
+	cases := []struct {
+		Input, Output string
+	}{
+		{"basic.hcl", "basic.golden"},
+	}
+
+	for _, tc := range cases {
+		source, _ := filepath.Abs(filepath.Join("./test-fixtures", tc.Input))
+		output, _ := filepath.Abs(filepath.Join("./test-fixtures", tc.Output))
+		check(t, source, output, *update)
+	}
+}
+
+func check(t *testing.T, source, golden string, update bool) {
+	actual, err := ParseFile(source)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	res, err := format(actual)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// update golden files if necessary
+	if update {
+		if err := ioutil.WriteFile(golden, res, 0644); err != nil {
+			t.Error(err)
+		}
+		return
+	}
+
+	// get golden
+	gld, err := ioutil.ReadFile(golden)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// formatted source and golden must be the same
+	if err := diff(source, golden, res, gld); err != nil {
+		t.Error(err)
+		return
+	}
+}
+
+// diff compares a and b.
+func diff(aname, bname string, a, b []byte) error {
+	var buf bytes.Buffer // holding long error message
+
+	// compare lengths
+	if len(a) != len(b) {
+		fmt.Fprintf(&buf, "\nlength changed: len(%s) = %d, len(%s) = %d", aname, len(a), bname, len(b))
+	}
+
+	// compare contents
+	line := 1
+	offs := 1
+	for i := 0; i < len(a) && i < len(b); i++ {
+		ch := a[i]
+		if ch != b[i] {
+			fmt.Fprintf(&buf, "\n%s:%d:%d: %s", aname, line, i-offs+1, lineAt(a, offs))
+			fmt.Fprintf(&buf, "\n%s:%d:%d: %s", bname, line, i-offs+1, lineAt(b, offs))
+			fmt.Fprintf(&buf, "\n\n")
+			break
+		}
+		if ch == '\n' {
+			line++
+			offs = i + 1
+		}
+	}
+
+	if buf.Len() > 0 {
+		return errors.New(buf.String())
+	}
+	return nil
+}
+
+// format parses src, prints the corresponding AST, verifies the resulting
+// src is syntactically correct, and returns the resulting src or an error
+// if any.
+func format(f *File) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, f.HCL()); err != nil {
+		return nil, fmt.Errorf("print: %s", err)
+	}
+
+	// make sure formatted output is syntactically correct
+	res := buf.Bytes()
+	/*
+		if _, err := Parse(bytes.NewReader(res)); err != nil {
+			return nil, fmt.Errorf("parse: %s\n%s", err, f.Path)
+		}
+	*/
+
+	return res, nil
+}
+
+// lineAt returns the line in text starting at offset offs.
+func lineAt(text []byte, offs int) []byte {
+	i := offs
+	for i < len(text) && text[i] != '\n' {
+		i++
+	}
+	return text[offs:i]
+}

--- a/appfile/test-fixtures/basic.golden
+++ b/appfile/test-fixtures/basic.golden
@@ -1,6 +1,5 @@
 application {
   name = "foo"
-  type = ""
 
   dependency {
     source = "foo"

--- a/appfile/test-fixtures/basic.golden
+++ b/appfile/test-fixtures/basic.golden
@@ -1,0 +1,23 @@
+application {
+  name = "foo"
+  type = ""
+
+  dependency {
+    source = "foo"
+  }
+
+  dependency {
+    source = "bar"
+  }
+}
+
+project {
+  name           = "foo"
+  infrastructure = "aws"
+}
+
+infrastructure {
+  name   = "aws"
+  type   = "aws"
+  flavor = "foo"
+}


### PR DESCRIPTION
This adds an `HCL` method to the `*appfile.File` which makes it usable with the HCL printer library in order to output HCL. Tests are included that show example output.