### PR TITLE
otto: call Close if impl is io.Closer

### DIFF
--- a/app/mock.go
+++ b/app/mock.go
@@ -6,6 +6,8 @@ type Mock struct {
 	MetaResult *Meta
 	MetaErr    error
 
+	CloseCalled bool
+
 	CompileCalled  bool
 	CompileContext *Context
 	CompileResult  *CompileResult
@@ -34,6 +36,11 @@ type Mock struct {
 func (m *Mock) Meta() (*Meta, error) {
 	m.MetaCalled = true
 	return m.MetaResult, m.MetaErr
+}
+
+func (m *Mock) Close() error {
+	m.CloseCalled = true
+	return nil
 }
 
 func (m *Mock) Compile(ctx *Context) (*CompileResult, error) {

--- a/app/mock_test.go
+++ b/app/mock_test.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"io"
 	"testing"
 )
 
 func TestMock_impl(t *testing.T) {
 	var _ App = new(Mock)
+	var _ io.Closer = new(Mock)
 }

--- a/otto/closer.go
+++ b/otto/closer.go
@@ -1,0 +1,15 @@
+package otto
+
+import (
+	"io"
+)
+
+// maybeClose is a function that can easily be deferred or called at any
+// point and will close the given value if it is an io.Closer.
+func maybeClose(v interface{}) error {
+	if c, ok := v.(io.Closer); ok {
+		return c.Close()
+	}
+
+	return nil
+}

--- a/otto/core_test.go
+++ b/otto/core_test.go
@@ -6,6 +6,26 @@ import (
 	"github.com/hashicorp/otto/app"
 )
 
+func TestCoreCompile_close(t *testing.T) {
+	// Make a core that returns a fixed app
+	coreConfig := TestCoreConfig(t)
+	coreConfig.Appfile = TestAppfile(t, testPath("basic", "Appfile"))
+	appMock := TestApp(t, TestAppTuple, coreConfig)
+	core := testCore(t, coreConfig)
+
+	// Compile!
+	if err := core.Compile(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !appMock.CompileCalled {
+		t.Fatal("compile should be called")
+	}
+	if !appMock.CloseCalled {
+		t.Fatal("close should be called")
+	}
+}
+
 func TestCoreDev_compileMetadata(t *testing.T) {
 	// Make a core that returns a fixed app
 	coreConfig := TestCoreConfig(t)


### PR DESCRIPTION
This makes it so the Core calls `Close` if any interface impl is an io.Closer. This cleans up plugins for us throughout the core.