### PR TITLE
Enable linked clones for Vagrant Parallels provider

### DIFF
--- a/helper/compile/data/app/dev/Vagrantfile-layer.tpl
+++ b/helper/compile/data/app/dev/Vagrantfile-layer.tpl
@@ -22,6 +22,12 @@ Vagrant.configure("2") do |config|
     v.linked_clone = true
   end
 
+  if Vagrant.has_plugin?("vagrant-parallels", ">= 1.6.0")
+    config.vm.provider "parallels" do |p|
+      p.linked_clone = true
+    end
+  end
+
   # Disable the default synced folder
   config.vm.synced_folder ".", "/vagrant", disabled: true
 

--- a/helper/compile/data/app/dev/Vagrantfile.tpl
+++ b/helper/compile/data/app/dev/Vagrantfile.tpl
@@ -46,6 +46,12 @@ Vagrant.configure("2") do |config|
     p.linked_clone = true
   end
 
+  if Vagrant.has_plugin?("vagrant-parallels", ">= 1.6.0")
+    config.vm.provider "parallels" do |p|
+      p.linked_clone = true
+    end
+  end
+
   # This is to work around some bugs right now
   ["vmware_fusion", "vmware_workstation"].each do |name|
     config.vm.provider(name) do |p|


### PR DESCRIPTION
This PR enable "linked clone" feature for envs created with Parallels provider.

Option "linked_clone" is available in "vagrant-parallels" >=1.6.0, which we will release as soon as Vagrant 1.8.0 is released.

P.s. By the way, we will also support layered envs there (https://github.com/Parallels/vagrant-parallels/pull/224) :wink: 