### PR TITLE
Packer: explicitly set vpc & subnet 

### DIFF
--- a/builtin/app/node/app.go
+++ b/builtin/app/node/app.go
@@ -59,6 +59,8 @@ func (a *App) Build(ctx *app.Context) error {
 	return packer.Build(ctx, &packer.BuildOptions{
 		InfraOutputMap: map[string]string{
 			"region": "aws_region",
+			"vpc_id": "aws_vpc_id",
+			"subnet_public":  "aws_subnet_id",
 		},
 	})
 }

--- a/builtin/app/node/data/aws-simple/build/template.json.tpl
+++ b/builtin/app/node/data/aws-simple/build/template.json.tpl
@@ -5,6 +5,8 @@
       "aws_access_key": null,
       "aws_secret_key": null,
       "aws_region": null,
+      "aws_vpc_id": null,
+      "aws_subnet_id": null,
       "slug_path": null
     },
 
@@ -41,6 +43,8 @@
       "access_key": "{% verbatim %}{{ user `aws_access_key` }}{% endverbatim %}",
       "secret_key": "{% verbatim %}{{ user `aws_secret_key` }}{% endverbatim %}",
       "region": "{% verbatim %}{{ user `aws_region` }}{% endverbatim %}",
+      "vpc_id": "{% verbatim %}{{ user `aws_vpc_id` }}{% endverbatim %}",
+      "subnet_id": "{% verbatim %}{{ user `aws_subnet_id` }}{% endverbatim %}",
       "source_ami": "ami-21630d44",
       "instance_type": "c3.large",
       "ssh_username": "ubuntu",

--- a/builtin/app/php/app.go
+++ b/builtin/app/php/app.go
@@ -53,6 +53,8 @@ func (a *App) Build(ctx *app.Context) error {
 	return packer.Build(ctx, &packer.BuildOptions{
 		InfraOutputMap: map[string]string{
 			"region": "aws_region",
+			"vpc_id": "aws_vpc_id",
+			"subnet_public":  "aws_subnet_id",
 		},
 	})
 }

--- a/builtin/app/php/data/aws-simple/build/template.json.tpl
+++ b/builtin/app/php/data/aws-simple/build/template.json.tpl
@@ -5,6 +5,8 @@
       "aws_access_key": null,
       "aws_secret_key": null,
       "aws_region": null,
+      "aws_vpc_id": null,
+      "aws_subnet_id": null,
       "slug_path": null
     },
 
@@ -41,6 +43,8 @@
       "access_key": "{% verbatim %}{{ user `aws_access_key` }}{% endverbatim %}",
       "secret_key": "{% verbatim %}{{ user `aws_secret_key` }}{% endverbatim %}",
       "region": "{% verbatim %}{{ user `aws_region` }}{% endverbatim %}",
+      "vpc_id": "{% verbatim %}{{ user `aws_vpc_id` }}{% endverbatim %}",
+      "subnet_id": "{% verbatim %}{{ user `aws_subnet_id` }}{% endverbatim %}",
       "source_ami": "ami-21630d44",
       "instance_type": "c3.large",
       "ssh_username": "ubuntu",

--- a/builtin/app/ruby/app.go
+++ b/builtin/app/ruby/app.go
@@ -59,6 +59,8 @@ func (a *App) Build(ctx *app.Context) error {
 	return packer.Build(ctx, &packer.BuildOptions{
 		InfraOutputMap: map[string]string{
 			"region": "aws_region",
+			"vpc_id": "aws_vpc_id",
+			"subnet_public":  "aws_subnet_id",
 		},
 	})
 }

--- a/builtin/app/ruby/data/aws-simple/build/template.json.tpl
+++ b/builtin/app/ruby/data/aws-simple/build/template.json.tpl
@@ -5,6 +5,8 @@
       "aws_access_key": null,
       "aws_secret_key": null,
       "aws_region": null,
+      "aws_vpc_id": null,
+      "aws_subnet_id": null,
       "slug_path": null
     },
 
@@ -41,6 +43,8 @@
       "access_key": "{% verbatim %}{{ user `aws_access_key` }}{% endverbatim %}",
       "secret_key": "{% verbatim %}{{ user `aws_secret_key` }}{% endverbatim %}",
       "region": "{% verbatim %}{{ user `aws_region` }}{% endverbatim %}",
+      "vpc_id": "{% verbatim %}{{ user `aws_vpc_id` }}{% endverbatim %}",
+      "subnet_id": "{% verbatim %}{{ user `aws_subnet_id` }}{% endverbatim %}",
       "source_ami": "ami-21630d44",
       "instance_type": "c3.large",
       "ssh_username": "ubuntu",

--- a/builtin/app/ruby/data/aws-vpc-public-private/build/template.json.tpl
+++ b/builtin/app/ruby/data/aws-vpc-public-private/build/template.json.tpl
@@ -5,6 +5,8 @@
       "aws_access_key": null,
       "aws_secret_key": null,
       "aws_region": null,
+      "aws_vpc_id": null,
+      "aws_subnet_id": null,
       "slug_path": null
     },
 
@@ -41,6 +43,8 @@
       "access_key": "{% verbatim %}{{ user `aws_access_key` }}{% endverbatim %}",
       "secret_key": "{% verbatim %}{{ user `aws_secret_key` }}{% endverbatim %}",
       "region": "{% verbatim %}{{ user `aws_region` }}{% endverbatim %}",
+      "vpc_id": "{% verbatim %}{{ user `aws_vpc_id` }}{% endverbatim %}",
+      "subnet_id": "{% verbatim %}{{ user `aws_subnet_id` }}{% endverbatim %}",
       "source_ami": "ami-21630d44",
       "instance_type": "c3.large",
       "ssh_username": "ubuntu",


### PR DESCRIPTION
If a user deleted their default VPC then Packer would generate an error. Instead lets use the same vpc/subnet generated by `otto infra`.

Issue
#235