### PR TITLE
Summary: Fixes issue #352

### DIFF
--- a/builtin/foundation/consul/data/common/app-dev/layer.sh.tpl
+++ b/builtin/foundation/consul/data/common/app-dev/layer.sh.tpl
@@ -28,7 +28,7 @@ EOF
     oe sudo mv /tmp/consul_flags /etc/service/consul
 
     # Setup Consul service and start it
-    oe sudo mv ${dir}/upstart.conf /etc/init/consul.conf
+    oe sudo cp ${dir}/upstart.conf /etc/init/consul.conf
 
     # Setup DNS
     ol "Installing dnsmasq for Consul..."

--- a/builtin/foundation/consul/data/common/app-dev/main.sh.tpl
+++ b/builtin/foundation/consul/data/common/app-dev/main.sh.tpl
@@ -28,7 +28,7 @@ EOF
     oe sudo mv /tmp/consul_flags /etc/service/consul
 
     # Setup Consul service and start it
-    oe sudo mv ${dir}/upstart.conf /etc/init/consul.conf
+    oe sudo cp ${dir}/upstart.conf /etc/init/consul.conf
 
     # Setup DNS
     ol "Installing dnsmasq for Consul..."


### PR DESCRIPTION
Changesets:
- In app-build/main.sh.tpl; it correctly uses cp so can be run multiple times
- Only in app-dev/layer.sh.tpl and app-dev/layer.sh.tpl it uses mv
- This means; if otto destroy is invoked without re-running otto compile; it will fail


Before running 'otto dev'
```
compiled leow$ find . -name upstart.conf
./app/foundation-consul/app-build/upstart.conf
./app/foundation-consul/app-dev/upstart.conf
./dep-24cbbebc-fc41-53b4-c844-60d642fb523c/foundation-consul/app-build/upstart.conf
./dep-24cbbebc-fc41-53b4-c844-60d642fb523c/foundation-consul/app-dev/upstart.conf
./foundation-consul/app-build/upstart.conf
./foundation-consul/app-dev/upstart.conf
```

After running 'otto dev'; upstart,conf is missing as reported
```
compiled leow$ find . -name upstart.conf
./app/foundation-consul/app-build/upstart.conf
./dep-24cbbebc-fc41-53b4-c844-60d642fb523c/foundation-consul/app-build/upstart.conf
./dep-24cbbebc-fc41-53b4-c844-60d642fb523c/foundation-consul/app-dev/upstart.conf
./foundation-consul/app-build/upstart.conf
./foundation-consul/app-dev/upstart.conf
```