### PR TITLE
Fix for 403 on OSX

### DIFF
--- a/helper/hashitools/installer_vagrant.go
+++ b/helper/hashitools/installer_vagrant.go
@@ -71,7 +71,7 @@ func (i *VagrantInstaller) Install(vsn *version.Version) error {
 	switch runtime.GOOS {
 	case "darwin":
 		url = fmt.Sprintf(
-			"https://releases.hashicorp.com/vagrant/vagrant_%s/vagrant_%s.dmg",
+			"https://releases.hashicorp.com/vagrant/%s/vagrant_%s.dmg",
 			vsn, vsn)
 	default:
 		return fmt.Errorf(


### PR DESCRIPTION
With the changes from #353 I was seeing a `403`

```bash
...
==> Downloading Vagrant v1.7.4...
    URL: https://releases.hashicorp.com/vagrant/vagrant_1.7.4/vagrant_1.7.4.dmg

Error building dev environment: Error downloading, status code 403
...
```

This fixes it.