### PR TITLE
helper/vagrant: Use Vagrant machine readable output

### DIFF
--- a/helper/vagrant/ui.go
+++ b/helper/vagrant/ui.go
@@ -1,0 +1,137 @@
+package vagrant
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+
+	"github.com/armon/circbuf"
+	"github.com/hashicorp/otto/ui"
+)
+
+// OutputCallback is the type that is called when there is a matching
+// machine-readable output line for the UI.
+type OutputCallback func(*Output)
+
+// Output is a single line of machine-readable output from Vagrant.
+type Output struct {
+	Timestamp string
+	Target    string
+	Type      string
+	Data      []string
+}
+
+// vagrantUi is an implementation of ui.Ui that we pass to helper/exec
+// that parses the machine-readable output of Vagrant and calls callbacks
+// for the various entries.
+type vagrantUi struct {
+	Callbacks map[string]OutputCallback
+
+	buf  *circbuf.Buffer
+	once sync.Once
+}
+
+// Finish should be called when you're done to force the final newline
+// to parse the final event.
+func (u *vagrantUi) Finish() {
+	// We only need to do anything if we have stuff in our buffer
+	if u.buf != nil && u.buf.TotalWritten() > 0 {
+		u.Raw("\n")
+	}
+}
+
+// Ignore these because we don't use them from helper/exec
+func (u *vagrantUi) Header(string)                       {}
+func (u *vagrantUi) Message(string)                      {}
+func (u *vagrantUi) Input(*ui.InputOpts) (string, error) { return "", nil }
+
+func (u *vagrantUi) Raw(msg string) {
+	if msg == "" {
+		// Not sure how this would happen, but there is nothing to do here.
+		return
+	}
+
+	u.once.Do(u.init)
+
+	// We loop while we have a newline in the message
+	for {
+		// Get the index for the newline if there is one
+		idx := strings.IndexRune(msg, '\n')
+		if idx == -1 {
+			// The newline isn't there, write it to the circular buffer
+			// and wait longer.
+			u.buf.Write([]byte(msg))
+			break
+		}
+
+		// We got a newline! Grab the contents from the circular buffer and
+		// copy it so we can clear the buffer.
+		bufRaw := u.buf.Bytes()
+		buf := string(bufRaw) + msg[:idx]
+		bufRaw = nil
+		u.buf.Reset()
+
+		// If we have more data, clear msg to that point. If we have
+		// no more data, then just set message to empty and we'll break
+		// on the next loop iteration
+		if idx < len(msg) {
+			msg = msg[idx+1:]
+		} else {
+			msg = ""
+		}
+
+		// Combine the data from the buffer up to the newline so we
+		// have the full line, and split that by the commas.
+		parts := strings.Split(buf, ",")
+		if len(parts) < 3 {
+			// Uh, invalid event?
+			log.Printf("[ERROR] Invalid Vagrant event line: %s", buf)
+			return
+		}
+
+		// Look for the callback
+		cb, ok := u.Callbacks[parts[2]]
+		if !ok {
+			// No callback registered for this type, drop it
+			return
+		}
+
+		// We have a callback, construct the output!
+		var data []string
+		if len(parts) > 3 {
+			data = make([]string, len(parts)-3)
+			for i, raw := range parts[3:] {
+				data[i] = strings.Replace(
+					strings.Replace(
+						strings.Replace(raw, "%!(VAGRANT_COMMA)", ",", -1),
+						"\\n", "\n", -1),
+					"\\r", "\r", -1)
+			}
+		}
+
+		// Callback
+		cb(&Output{
+			Timestamp: parts[0],
+			Target:    parts[1],
+			Type:      parts[2],
+			Data:      data,
+		})
+	}
+}
+
+func (u *vagrantUi) init() {
+	// Allocating the circular buffer. The circular buffer should only
+	// keep track up to the point that there is a \n found so it doesn't
+	// need to be huge, but it also limits the max length of an event.
+	var err error
+	u.buf, err = circbuf.NewBuffer(4096)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// For testing
+func (o *Output) GoString() string {
+	return fmt.Sprintf("*%#v", *o)
+}

--- a/helper/vagrant/ui.go
+++ b/helper/vagrant/ui.go
@@ -71,6 +71,7 @@ func (u *vagrantUi) Raw(msg string) {
 		buf := string(bufRaw) + msg[:idx]
 		bufRaw = nil
 		u.buf.Reset()
+		log.Printf("[DEBUG] Vagrant output line: %s", buf)
 
 		// If we have more data, clear msg to that point. If we have
 		// no more data, then just set message to empty and we'll break

--- a/helper/vagrant/ui_test.go
+++ b/helper/vagrant/ui_test.go
@@ -1,0 +1,200 @@
+package vagrant
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVagrantUi(t *testing.T) {
+	cases := map[string]struct {
+		Types    []string
+		Messages []string
+		Outputs  []*Output
+	}{
+		"basic": {
+			[]string{"ui"},
+			[]string{"1376289459,,ui,say,foo bar"},
+			[]*Output{
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"foo bar",
+					},
+				},
+			},
+		},
+
+		"multiple": {
+			[]string{"ui"},
+			[]string{
+				"1376289459,,ui,say,foo bar",
+				"\n",
+				"1376289459,,ui,say,baz",
+			},
+			[]*Output{
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"foo bar",
+					},
+				},
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"baz",
+					},
+				},
+			},
+		},
+
+		"multiple in one": {
+			[]string{"ui"},
+			[]string{
+				"1376289459,,ui,say,foo bar\n1376289459,,ui,say,baz\n1376289459,,ui,say,qux",
+			},
+			[]*Output{
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"foo bar",
+					},
+				},
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"baz",
+					},
+				},
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"qux",
+					},
+				},
+			},
+		},
+
+		"trailing newline": {
+			[]string{"ui"},
+			[]string{
+				"1376289459,,ui,say,foo bar",
+				"\n",
+				"1376289459,,ui,say,baz\n",
+			},
+			[]*Output{
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"foo bar",
+					},
+				},
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"baz",
+					},
+				},
+			},
+		},
+
+		"newlines in data": {
+			[]string{"ui"},
+			[]string{"1376289459,,ui,say,foo\\nbar"},
+			[]*Output{
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"foo\nbar",
+					},
+				},
+			},
+		},
+
+		"carriage return in data": {
+			[]string{"ui"},
+			[]string{"1376289459,,ui,say,foo\\rbar"},
+			[]*Output{
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"foo\rbar",
+					},
+				},
+			},
+		},
+
+		"comma in data": {
+			[]string{"ui"},
+			[]string{"1376289459,,ui,say,foo%!(VAGRANT_COMMA)bar"},
+			[]*Output{
+				&Output{
+					Timestamp: "1376289459",
+					Target:    "",
+					Type:      "ui",
+					Data: []string{
+						"say",
+						"foo,bar",
+					},
+				},
+			},
+		},
+
+		"unregistered type": {
+			[]string{"ui"},
+			[]string{"1376289459,,not-ui,say,foo bar"},
+			[]*Output{},
+		},
+	}
+
+	for name, tc := range cases {
+		actual := make([]*Output, 0, len(tc.Outputs))
+		recordCallback := func(o *Output) {
+			actual = append(actual, o)
+		}
+
+		callbacks := make(map[string]OutputCallback)
+		for _, t := range tc.Types {
+			callbacks[t] = recordCallback
+		}
+
+		ui := &vagrantUi{Callbacks: callbacks}
+		for _, msg := range tc.Messages {
+			ui.Raw(msg)
+		}
+		ui.Finish()
+
+		if !reflect.DeepEqual(actual, tc.Outputs) {
+			t.Fatalf("%s\n\n%#v\n\n%#v", name, actual, tc.Outputs)
+		}
+	}
+}

--- a/helper/vagrant/vagrant.go
+++ b/helper/vagrant/vagrant.go
@@ -109,7 +109,7 @@ func (v *Vagrant) Execute(commandRaw ...string) error {
 	ui := &vagrantUi{Callbacks: callbacks}
 
 	// Run it with the execHelper
-	err := execHelper.Run(v.Ui, cmd)
+	err := execHelper.Run(ui, cmd)
 	ui.Finish()
 	if err != nil {
 		return fmt.Errorf(

--- a/helper/vagrant/vagrant.go
+++ b/helper/vagrant/vagrant.go
@@ -69,7 +69,7 @@ const (
 )
 
 // Execute executes a raw Vagrant command.
-func (v *Vagrant) Execute(command ...string) error {
+func (v *Vagrant) Execute(commandRaw ...string) error {
 	vagrantMutex.Lock()
 	defer vagrantMutex.Unlock()
 
@@ -88,6 +88,11 @@ func (v *Vagrant) Execute(command ...string) error {
 	for k, v := range v.Env {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
+
+	// Build the args
+	command := make([]string, len(commandRaw)+1)
+	command[0] = "--machine-readable"
+	copy(command[1:], commandRaw)
 
 	// Build the command to execute
 	cmd := exec.Command("vagrant", command...)


### PR DESCRIPTION
This modifies `helper/vagrant` to be more like Packer where it always uses machine-readable output. This will give us more flexibility in the future to more easily grab info we need as we get it. 

This makes no functional changes.