### PR TITLE
helper/vagrant: use machine-readable output to capture SSH config

### DIFF
--- a/helper/vagrant/ssh.go
+++ b/helper/vagrant/ssh.go
@@ -1,6 +1,7 @@
 package vagrant
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -63,6 +64,13 @@ func (c *SSHCache) Cache() error {
 	}
 	if err := vagrant.Execute("ssh-config"); err != nil {
 		return err
+	}
+
+	// If we have no output, it is an error
+	if result == "" {
+		return fmt.Errorf(
+			"No SSH info found in the output of Vagrant. This is a bug somewhere.\n" +
+				"Please re-run the command with OTTO_LOG=1 and report this as a bug.")
 	}
 
 	// Write the output to the cache

--- a/helper/vagrant/ssh.go
+++ b/helper/vagrant/ssh.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/hashicorp/otto/ui"
 )
 
 // SSHCache is a helper to cache the SSH connection info from Vagrant


### PR DESCRIPTION
Fixes GH-343

This uses the machine-readable output stuff we just introduced as part of Vagrant 1.8 to capture only the pure SSH config.