### PR TITLE
Simplified and more well defined customization configuration in Appfiles

### DIFF
--- a/appfile/customization.go
+++ b/appfile/customization.go
@@ -31,7 +31,7 @@ func (s *CustomizationSet) Filter(t string) []*Customization {
 	// to just over-allocate here.
 	result := make([]*Customization, 0, len(s.Raw))
 	for _, c := range s.Raw {
-		if c.Type == t {
+		if c.Name == t {
 			result = append(result, c)
 		}
 	}

--- a/appfile/customization.go
+++ b/appfile/customization.go
@@ -31,7 +31,7 @@ func (s *CustomizationSet) Filter(t string) []*Customization {
 	// to just over-allocate here.
 	result := make([]*Customization, 0, len(s.Raw))
 	for _, c := range s.Raw {
-		if c.Name == t {
+		if c.Type == t {
 			result = append(result, c)
 		}
 	}

--- a/appfile/customization_test.go
+++ b/appfile/customization_test.go
@@ -13,23 +13,23 @@ func TestCustomizationSetFilter(t *testing.T) {
 	}{
 		{
 			[]*Customization{
-				&Customization{Name: "foo"},
-				&Customization{Name: "bar"},
+				&Customization{Type: "foo"},
+				&Customization{Type: "bar"},
 			},
 			"foo",
 			[]*Customization{
-				&Customization{Name: "foo"},
+				&Customization{Type: "foo"},
 			},
 		},
 
 		{
 			[]*Customization{
-				&Customization{Name: "foo"},
-				&Customization{Name: "bar"},
+				&Customization{Type: "foo"},
+				&Customization{Type: "bar"},
 			},
 			"fOo",
 			[]*Customization{
-				&Customization{Name: "foo"},
+				&Customization{Type: "foo"},
 			},
 		},
 	}

--- a/appfile/customization_test.go
+++ b/appfile/customization_test.go
@@ -13,23 +13,23 @@ func TestCustomizationSetFilter(t *testing.T) {
 	}{
 		{
 			[]*Customization{
-				&Customization{Type: "foo"},
-				&Customization{Type: "bar"},
+				&Customization{Name: "foo"},
+				&Customization{Name: "bar"},
 			},
 			"foo",
 			[]*Customization{
-				&Customization{Type: "foo"},
+				&Customization{Name: "foo"},
 			},
 		},
 
 		{
 			[]*Customization{
-				&Customization{Type: "foo"},
-				&Customization{Type: "bar"},
+				&Customization{Name: "foo"},
+				&Customization{Name: "bar"},
 			},
 			"fOo",
 			[]*Customization{
-				&Customization{Type: "foo"},
+				&Customization{Name: "foo"},
 			},
 		},
 	}

--- a/appfile/file.go
+++ b/appfile/file.go
@@ -52,7 +52,7 @@ type Application struct {
 // Customization is the structure of customization stanzas within
 // the Appfile.
 type Customization struct {
-	Name   string
+	Type   string
 	Config map[string]interface{}
 }
 

--- a/appfile/file.go
+++ b/appfile/file.go
@@ -52,7 +52,7 @@ type Application struct {
 // Customization is the structure of customization stanzas within
 // the Appfile.
 type Customization struct {
-	Type   string
+	Name   string
 	Config map[string]interface{}
 }
 

--- a/appfile/file_hcl.go
+++ b/appfile/file_hcl.go
@@ -78,12 +78,12 @@ func (f *Customization) HCL() *ast.ObjectItem {
 	return &ast.ObjectItem{
 		Keys: []*ast.ObjectKey{
 			&ast.ObjectKey{
-				Token: token.Token{Type: token.IDENT, Text: "dependency"},
+				Token: token.Token{Type: token.IDENT, Text: "customization"},
 			},
 			&ast.ObjectKey{
 				Token: token.Token{
 					Type: token.STRING,
-					Text: fmt.Sprintf(`"%s"`, f.Type),
+					Text: fmt.Sprintf(`"%s"`, f.Name),
 				},
 			},
 		},

--- a/appfile/file_hcl.go
+++ b/appfile/file_hcl.go
@@ -83,7 +83,7 @@ func (f *Customization) HCL() *ast.ObjectItem {
 			&ast.ObjectKey{
 				Token: token.Token{
 					Type: token.STRING,
-					Text: fmt.Sprintf(`"%s"`, f.Name),
+					Text: fmt.Sprintf(`"%s"`, f.Type),
 				},
 			},
 		},

--- a/appfile/file_test.go
+++ b/appfile/file_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/mitchellh/copystructure"
 )
 
 func TestFileActiveInfrastructure(t *testing.T) {
@@ -266,5 +268,21 @@ func TestFileMerge(t *testing.T) {
 		if !reflect.DeepEqual(tc.One, tc.Three) {
 			t.Fatalf("%s:\n\n%#v\n\n%#v", name, tc.One, tc.Three)
 		}
+	}
+}
+
+func TestFileDeepCopy(t *testing.T) {
+	f, err := ParseFile(filepath.Join("./test-fixtures", "basic.hcl"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	f2, err := copystructure.Copy(f)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(f, f2) {
+		t.Fatalf("bad:\n\n%#v\n\n%#v", f, f2)
 	}
 }

--- a/appfile/parse.go
+++ b/appfile/parse.go
@@ -142,7 +142,7 @@ func parseCustomizations(result *File, list *ast.ObjectList) error {
 	// Go through each object and turn it into an actual result.
 	collection := make([]*Customization, 0, len(list.Items))
 	for _, item := range list.Items {
-		var key string
+		key := "app"
 		if len(item.Keys) > 0 {
 			key = item.Keys[0].Token.Value().(string)
 		}

--- a/appfile/parse.go
+++ b/appfile/parse.go
@@ -139,15 +139,13 @@ func parseApplication(result *File, list *ast.ObjectList) error {
 }
 
 func parseCustomizations(result *File, list *ast.ObjectList) error {
-	list = list.Children()
-	if len(list.Items) == 0 {
-		return nil
-	}
-
 	// Go through each object and turn it into an actual result.
 	collection := make([]*Customization, 0, len(list.Items))
 	for _, item := range list.Items {
-		key := item.Keys[0].Token.Value().(string)
+		var key string
+		if len(item.Keys) > 0 {
+			key = item.Keys[0].Token.Value().(string)
+		}
 
 		var m map[string]interface{}
 		if err := hcl.DecodeObject(&m, item.Val); err != nil {
@@ -155,7 +153,7 @@ func parseCustomizations(result *File, list *ast.ObjectList) error {
 		}
 
 		var c Customization
-		c.Type = strings.ToLower(key)
+		c.Name = strings.ToLower(key)
 		c.Config = m
 
 		collection = append(collection, &c)

--- a/appfile/parse.go
+++ b/appfile/parse.go
@@ -153,7 +153,7 @@ func parseCustomizations(result *File, list *ast.ObjectList) error {
 		}
 
 		var c Customization
-		c.Name = strings.ToLower(key)
+		c.Type = strings.ToLower(key)
 		c.Config = m
 
 		collection = append(collection, &c)

--- a/appfile/parse_test.go
+++ b/appfile/parse_test.go
@@ -84,7 +84,7 @@ func TestParse(t *testing.T) {
 				Customization: &CustomizationSet{
 					Raw: []*Customization{
 						&Customization{
-							Type: "",
+							Type: "app",
 							Config: map[string]interface{}{
 								"go_version": "1.5",
 							},

--- a/appfile/parse_test.go
+++ b/appfile/parse_test.go
@@ -67,7 +67,7 @@ func TestParse(t *testing.T) {
 				Customization: &CustomizationSet{
 					Raw: []*Customization{
 						&Customization{
-							Name: "dev",
+							Type: "dev",
 							Config: map[string]interface{}{
 								"go_version": "1.5",
 							},
@@ -84,7 +84,7 @@ func TestParse(t *testing.T) {
 				Customization: &CustomizationSet{
 					Raw: []*Customization{
 						&Customization{
-							Name: "",
+							Type: "",
 							Config: map[string]interface{}{
 								"go_version": "1.5",
 							},
@@ -101,7 +101,7 @@ func TestParse(t *testing.T) {
 				Customization: &CustomizationSet{
 					Raw: []*Customization{
 						&Customization{
-							Name: "dev",
+							Type: "dev",
 							Config: map[string]interface{}{
 								"go_version": "1.5",
 							},

--- a/appfile/parse_test.go
+++ b/appfile/parse_test.go
@@ -67,7 +67,24 @@ func TestParse(t *testing.T) {
 				Customization: &CustomizationSet{
 					Raw: []*Customization{
 						&Customization{
-							Type: "dev",
+							Name: "dev",
+							Config: map[string]interface{}{
+								"go_version": "1.5",
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+
+		{
+			"basic-custom-no-name.hcl",
+			&File{
+				Customization: &CustomizationSet{
+					Raw: []*Customization{
+						&Customization{
+							Name: "",
 							Config: map[string]interface{}{
 								"go_version": "1.5",
 							},
@@ -84,7 +101,7 @@ func TestParse(t *testing.T) {
 				Customization: &CustomizationSet{
 					Raw: []*Customization{
 						&Customization{
-							Type: "dev",
+							Name: "dev",
 							Config: map[string]interface{}{
 								"go_version": "1.5",
 							},

--- a/appfile/test-fixtures/basic-custom-no-name.hcl
+++ b/appfile/test-fixtures/basic-custom-no-name.hcl
@@ -1,0 +1,3 @@
+customization {
+    go_version = "1.5"
+}

--- a/builtin/app/custom/app.go
+++ b/builtin/app/custom/app.go
@@ -49,48 +49,27 @@ func (a *App) Compile(ctx *app.Context) (*app.CompileResult, error) {
 		FoundationConfig: foundation.Config{
 			ServiceName: ctx.Application.Name,
 		},
-		Customizations: []*compile.Customization{
-			&compile.Customization{
-				Type:     "dev",
-				Callback: custom.processDev,
-				Schema: map[string]*schema.FieldSchema{
-					"vagrantfile": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Description: "Path to Vagrantfile",
-					},
+		Customization: &compile.Customization{
+			Callback: custom.process,
+			Schema: map[string]*schema.FieldSchema{
+				"dev_vagrantfile": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Description: "Path to Vagrantfile",
 				},
-			},
 
-			&compile.Customization{
-				Type:     "dev-dep",
-				Callback: custom.processDevDep,
-				Schema: map[string]*schema.FieldSchema{
-					"vagrantfile": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Description: "Path to Vagrantfile template",
-					},
+				"dep_vagrantfile": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Description: "Path to Vagrantfile template",
 				},
-			},
 
-			&compile.Customization{
-				Type:     "build",
-				Callback: custom.processBuild,
-				Schema: map[string]*schema.FieldSchema{
-					"packer": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Description: "Path to Packer template",
-					},
+				"packer": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Description: "Path to Packer template",
 				},
-			},
 
-			&compile.Customization{
-				Type:     "deploy",
-				Callback: custom.processDeploy,
-				Schema: map[string]*schema.FieldSchema{
-					"terraform": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Description: "Path to a Terraform module",
-					},
+				"terraform": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Description: "Path to a Terraform module",
 				},
 			},
 		},

--- a/builtin/app/custom/customization.go
+++ b/builtin/app/custom/customization.go
@@ -11,46 +11,26 @@ type customizations struct {
 	Opts *compile.AppOptions
 }
 
-func (c *customizations) processBuild(d *schema.FieldData) error {
-	p, ok := d.GetOk("packer")
-	if !ok {
-		return nil
+func (c *customizations) process(d *schema.FieldData) error {
+	if p, ok := d.GetOk("packer"); ok {
+		c.Opts.Bindata.Context["build_packer_path"] = p.(string)
+		c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomBuild(d))
 	}
 
-	c.Opts.Bindata.Context["build_packer_path"] = p.(string)
-	c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomBuild(d))
-	return nil
-}
-
-func (c *customizations) processDeploy(d *schema.FieldData) error {
-	tf, ok := d.GetOk("terraform")
-	if !ok {
-		return nil
+	if tf, ok := d.GetOk("terraform"); ok {
+		c.Opts.Bindata.Context["deploy_terraform_path"] = tf.(string)
+		c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomDeploy(d))
 	}
 
-	c.Opts.Bindata.Context["deploy_terraform_path"] = tf.(string)
-	c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomDeploy(d))
-	return nil
-}
-
-func (c *customizations) processDev(d *schema.FieldData) error {
-	p, ok := d.GetOk("vagrantfile")
-
-	if !ok {
-		return nil
+	if p, ok := d.GetOk("dev_vagrantfile"); ok {
+		c.Opts.Bindata.Context["dev_vagrant_path"] = p.(string)
+		c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomDev(d))
 	}
 
-	c.Opts.Bindata.Context["dev_vagrant_path"] = p.(string)
-	c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomDev(d))
-	return nil
-}
-
-func (c *customizations) processDevDep(d *schema.FieldData) error {
-	if _, ok := d.GetOk("vagrantfile"); !ok {
-		return nil
+	if _, ok := d.GetOk("dep_vagrantfile"); ok {
+		c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomDevDep(d))
 	}
 
-	c.Opts.Callbacks = append(c.Opts.Callbacks, c.compileCustomDevDep(d))
 	return nil
 }
 

--- a/builtin/app/docker-external/app.go
+++ b/builtin/app/docker-external/app.go
@@ -52,25 +52,22 @@ func (a *App) Compile(ctx *app.Context) (*app.CompileResult, error) {
 				},
 			},
 		},
-		Customizations: []*compile.Customization{
-			&compile.Customization{
-				Type:     "docker",
-				Callback: custom.processDocker,
-				Schema: map[string]*schema.FieldSchema{
-					"image": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "",
-						Description: "Image name to run",
-					},
+		Customization: (&compile.Customization{
+			Callback: custom.process,
+			Schema: map[string]*schema.FieldSchema{
+				"image": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "",
+					Description: "Image name to run",
+				},
 
-					"run_args": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "",
-						Description: "Args to pass to `docker run`",
-					},
+				"run_args": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "",
+					Description: "Args to pass to `docker run`",
 				},
 			},
-		},
+		}).Merge(compile.VagrantCustomizations(&opts)),
 	}
 
 	return compile.App(&opts)

--- a/builtin/app/docker-external/customization.go
+++ b/builtin/app/docker-external/customization.go
@@ -9,7 +9,7 @@ type customizations struct {
 	Opts *compile.AppOptions
 }
 
-func (c *customizations) processDocker(d *schema.FieldData) error {
+func (c *customizations) process(d *schema.FieldData) error {
 	image := d.Get("image").(string)
 	if image == "" {
 		image = c.Opts.Ctx.Application.Name

--- a/builtin/app/go/app.go
+++ b/builtin/app/go/app.go
@@ -52,37 +52,28 @@ func (a *App) Compile(ctx *app.Context) (*app.CompileResult, error) {
 				},
 			},
 		},
-		Customizations: append([]*compile.Customization{
-			&compile.Customization{
-				Type:     "go",
-				Callback: custom.processGo,
-				Schema: map[string]*schema.FieldSchema{
-					"go_version": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "1.5",
-						Description: "Go version to install",
-					},
+		Customization: (&compile.Customization{
+			Callback: custom.process,
+			Schema: map[string]*schema.FieldSchema{
+				"go_version": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "1.5",
+					Description: "Go version to install",
+				},
 
-					"import_path": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "",
-						Description: "Go import path for where to put this in the GOPATH",
-					},
+				"go_import_path": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "",
+					Description: "Go import path for where to put this in the GOPATH",
+				},
+
+				"run_command": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "{{ dep_binary_path }}",
+					Description: "Command to run this app as a dep",
 				},
 			},
-
-			&compile.Customization{
-				Type:     "dev-dep",
-				Callback: custom.processDevDep,
-				Schema: map[string]*schema.FieldSchema{
-					"run_command": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "{{ dep_binary_path }}",
-						Description: "Command to run this app as a dep",
-					},
-				},
-			},
-		}, compile.VagrantCustomizations(&opts)...),
+		}).Merge(compile.VagrantCustomizations(&opts)),
 	}
 
 	return compile.App(&opts)

--- a/builtin/app/go/customization.go
+++ b/builtin/app/go/customization.go
@@ -11,17 +11,14 @@ type customizations struct {
 	Opts *compile.AppOptions
 }
 
-func (c *customizations) processDevDep(d *schema.FieldData) error {
+func (c *customizations) process(d *schema.FieldData) error {
 	cmd, err := c.Opts.Bindata.RenderString(d.Get("run_command").(string))
 	if err != nil {
 		return fmt.Errorf("Error processing 'run_command': %s", err)
 	}
 
 	c.Opts.Bindata.Context["dep_run_command"] = cmd
-	return nil
-}
 
-func (c *customizations) processGo(d *schema.FieldData) error {
 	c.Opts.Bindata.Context["dev_go_version"] = d.Get("go_version")
 
 	// Go is really finicky about the GOPATH. To help make the dev
@@ -30,7 +27,7 @@ func (c *customizations) processGo(d *schema.FieldData) error {
 	//
 	// We use this GOPATH for example in Vagrant to setup the synced
 	// folder directly into the GOPATH properly. Magic!
-	gopathPath := d.Get("import_path").(string)
+	gopathPath := d.Get("go_import_path").(string)
 	if gopathPath == "" {
 		var err error
 		c.Opts.Ctx.Ui.Header("Detecting application import path for GOPATH...")

--- a/builtin/app/node/app.go
+++ b/builtin/app/node/app.go
@@ -42,19 +42,16 @@ func (a *App) Compile(ctx *app.Context) (*app.CompileResult, error) {
 			AssetDir: AssetDir,
 			Context:  map[string]interface{}{},
 		},
-		Customizations: append([]*compile.Customization{
-			&compile.Customization{
-				Type:     "node",
-				Callback: custom.processDev,
-				Schema: map[string]*schema.FieldSchema{
-					"node_version": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "4.1.0",
-						Description: "Node version to install",
-					},
+		Customization: (&compile.Customization{
+			Callback: custom.process,
+			Schema: map[string]*schema.FieldSchema{
+				"node_version": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "4.1.0",
+					Description: "Node version to install",
 				},
 			},
-		}, compile.VagrantCustomizations(&opts)...),
+		}).Merge(compile.VagrantCustomizations(&opts)),
 	}
 
 	return compile.App(&opts)

--- a/builtin/app/node/customization.go
+++ b/builtin/app/node/customization.go
@@ -9,7 +9,7 @@ type customizations struct {
 	Opts *compile.AppOptions
 }
 
-func (c *customizations) processDev(d *schema.FieldData) error {
+func (c *customizations) process(d *schema.FieldData) error {
 	c.Opts.Bindata.Context["node_version"] = d.Get("node_version")
 	return nil
 }

--- a/builtin/app/php/app.go
+++ b/builtin/app/php/app.go
@@ -36,19 +36,16 @@ func (a *App) Compile(ctx *app.Context) (*app.CompileResult, error) {
 			AssetDir: AssetDir,
 			Context:  map[string]interface{}{},
 		},
-		Customizations: append([]*compile.Customization{
-			&compile.Customization{
-				Type:     "php",
-				Callback: custom.processPhp,
-				Schema: map[string]*schema.FieldSchema{
-					"php_version": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "5.6",
-						Description: "PHP version to install",
-					},
+		Customization: (&compile.Customization{
+			Callback: custom.process,
+			Schema: map[string]*schema.FieldSchema{
+				"php_version": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "5.6",
+					Description: "PHP version to install",
 				},
 			},
-		}, compile.VagrantCustomizations(&opts)...),
+		}).Merge(compile.VagrantCustomizations(&opts)),
 	}
 
 	return compile.App(&opts)

--- a/builtin/app/php/customization.go
+++ b/builtin/app/php/customization.go
@@ -9,7 +9,7 @@ type customizations struct {
 	Opts *compile.AppOptions
 }
 
-func (c *customizations) processPhp(d *schema.FieldData) error {
+func (c *customizations) process(d *schema.FieldData) error {
 	c.Opts.Bindata.Context["php_version"] = d.Get("php_version")
 	return nil
 }

--- a/builtin/app/ruby/app.go
+++ b/builtin/app/ruby/app.go
@@ -42,19 +42,16 @@ func (a *App) Compile(ctx *app.Context) (*app.CompileResult, error) {
 			AssetDir: AssetDir,
 			Context:  map[string]interface{}{},
 		},
-		Customizations: append([]*compile.Customization{
-			&compile.Customization{
-				Type:     "ruby",
-				Callback: custom.processRuby,
-				Schema: map[string]*schema.FieldSchema{
-					"ruby_version": &schema.FieldSchema{
-						Type:        schema.TypeString,
-						Default:     "detect",
-						Description: "Ruby version to install",
-					},
+		Customization: (&compile.Customization{
+			Callback: custom.process,
+			Schema: map[string]*schema.FieldSchema{
+				"ruby_version": &schema.FieldSchema{
+					Type:        schema.TypeString,
+					Default:     "detect",
+					Description: "Ruby version to install",
 				},
 			},
-		}, compile.VagrantCustomizations(&opts)...),
+		}).Merge(compile.VagrantCustomizations(&opts)),
 	}
 
 	return compile.App(&opts)

--- a/builtin/app/ruby/customization.go
+++ b/builtin/app/ruby/customization.go
@@ -14,7 +14,7 @@ type customizations struct {
 	Opts *compile.AppOptions
 }
 
-func (c *customizations) processRuby(d *schema.FieldData) error {
+func (c *customizations) process(d *schema.FieldData) error {
 	vsn := d.Get("ruby_version")
 
 	// If we were asked to detect the version, we attempt to do so.

--- a/helper/compile/app.go
+++ b/helper/compile/app.go
@@ -36,9 +36,9 @@ type AppOptions struct {
 	// default template data if those keys are not set.
 	Bindata *bindata.Data
 
-	// Customizations is a list of helpers to process customizations
-	// in the Appfile. See the Customization docs for more information.
-	Customizations []*Customization
+	// Customization is used to configure the customizations for this
+	// application. See the Customization type docs for more info.
+	Customization *Customization
 
 	// Callbacks are called just prior to compilation completing.
 	Callbacks []CompileCallback
@@ -107,11 +107,9 @@ func App(opts *AppOptions) (*app.CompileResult, error) {
 	}
 
 	// Process the customizations!
-	err := processCustomizations(&processOpts{
-		Customizations: opts.Customizations,
-		Appfile:        ctx.Appfile,
-		Bindata:        data,
-	})
+	err := processCustomizations(
+		ctx.Appfile.Customization,
+		opts.Customization)
 	if err != nil {
 		return nil, err
 	}

--- a/helper/compile/custom_vagrant.go
+++ b/helper/compile/custom_vagrant.go
@@ -6,16 +6,13 @@ import (
 
 // VagrantCustomizations returns common Vagrant customizations that work
 // with the default settings of the app compilation helper.
-func VagrantCustomizations(opts *AppOptions) []*Customization {
-	return []*Customization{
-		&Customization{
-			Type:     "vagrant",
-			Callback: vagrantCustomizationCallback(opts),
-			Schema: map[string]*schema.FieldSchema{
-				"vagrantfile": &schema.FieldSchema{
-					Type:        schema.TypeString,
-					Description: "Vagrantfile contents to append for development.",
-				},
+func VagrantCustomizations(opts *AppOptions) *Customization {
+	return &Customization{
+		Callback: vagrantCustomizationCallback(opts),
+		Schema: map[string]*schema.FieldSchema{
+			"vagrantfile": &schema.FieldSchema{
+				Type:        schema.TypeString,
+				Description: "Vagrantfile contents to append for development.",
 			},
 		},
 	}

--- a/helper/compile/customization.go
+++ b/helper/compile/customization.go
@@ -60,9 +60,11 @@ func processCustomizations(cs *appfile.CustomizationSet, c *Customization) error
 
 	// Go through all the customizations and merge. We only do
 	// key-level merging.
-	for _, c := range cs.Raw {
-		for k, v := range c.Config {
-			rawData[k] = v
+	if cs != nil {
+		for _, c := range cs.Raw {
+			for k, v := range c.Config {
+				rawData[k] = v
+			}
 		}
 	}
 

--- a/helper/compile/customization.go
+++ b/helper/compile/customization.go
@@ -3,108 +3,84 @@ package compile
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/otto/appfile"
-	"github.com/hashicorp/otto/helper/bindata"
 	"github.com/hashicorp/otto/helper/schema"
 )
-
-// Customization defines how customizations are handled during
-// compilation and are used for both App and Infra compilations.
-//
-// Customizations are the "customization" stanzas within the Appfile.
-//
-// Customizations are processed by querying the type given and then
-// calling the Callback. The CustomizationResult that is returned will
-// modify the behavior of the compilation process.
-type Customization struct {
-	// Type is the type of the customization, such as "dev"
-	Type string
-
-	// Schema is the schema for the data. This will be automatically
-	// validated with the data from the configuration.
-	Schema map[string]*schema.FieldSchema
-
-	// Callback is called to process this customization.
-	Callback CustomizationFunc
-}
 
 // CustomizationFunc is the callback called for customizations.
 type CustomizationFunc func(*schema.FieldData) error
 
-type processOpts struct {
-	Customizations []*Customization
+// Customization is used to configure how customizations are processed.
+type Customization struct {
+	// Schema is the actual schema of the customization configuration. This
+	// will be type validated automatically.
+	Schema map[string]*schema.FieldSchema
 
-	Appfile *appfile.File
-	Bindata *bindata.Data
+	// Callback is the callback that is called to process this customization.
+	// This is guaranteed to be called even if there is no customization set
+	// to allow you to setup defaults.
+	Callback CustomizationFunc
 }
 
-func processCustomizations(opts *processOpts) error {
+// Merge will merge this customization with the other and return a new
+// customization. The original customization is not modified.
+func (c *Customization) Merge(other *Customization) *Customization {
+	result := &Customization{
+		Schema: make(map[string]*schema.FieldSchema),
+	}
+
+	// Merge the schemas
+	for k, v := range c.Schema {
+		result.Schema[k] = v
+	}
+	for k, v := range other.Schema {
+		result.Schema[k] = v
+	}
+
+	// Wrap the callbacks
+	result.Callback = func(d *schema.FieldData) error {
+		if err := c.Callback(d); err != nil {
+			return err
+		}
+
+		return other.Callback(d)
+	}
+
+	return result
+}
+
+func processCustomizations(cs *appfile.CustomizationSet, c *Customization) error {
 	// We process customizations below by going through multiple
 	// passes. We can very likely condense this into one for loop but
 	// it helps the semantic understanding to split it out and there should
 	// never be so many customizations where the optimizations here matter.
 
 	// We start by going through, building the FieldData.
-	data := make([]*schema.FieldData, len(opts.Customizations))
-	for i, c := range opts.Customizations {
-		raw := make(map[string]interface{})
+	rawData := make(map[string]interface{})
 
-		// Grab the real customizations
-		cs := opts.Appfile.Customization.Filter(c.Type)
-		if len(cs) > 0 {
-			// We just want the last one. We don't do any merging for now
-			// or validation of the earlier ones. I'm sure this will cause problems
-			// one day.
-			realC := cs[len(cs)-1]
-			raw = realC.Config
-		}
-
-		// Build the FieldData structure from it
-		data[i] = &schema.FieldData{
-			Raw:    raw,
-			Schema: c.Schema,
+	// Go through all the customizations and merge. We only do
+	// key-level merging.
+	for _, c := range cs.Raw {
+		for k, v := range c.Config {
+			rawData[k] = v
 		}
 	}
 
-	// Validate all the field data
-	var err error
-	for i, d := range data {
-		// This is a sparse slice, so if its nil ignore it
-		if d == nil {
-			continue
-		}
-
-		// Validate it. If it is valid, then we're fine.
-		verr := d.Validate()
-		if verr == nil {
-			continue
-		}
-
-		// Invalid, record the error
-		c := opts.Customizations[i]
-		err = multierror.Append(err, fmt.Errorf(
-			"Error in '%s' customization: %s", c.Type, verr))
+	// Build the FieldData structure from it
+	data := &schema.FieldData{
+		Raw:    rawData,
+		Schema: c.Schema,
 	}
 
-	// If we have validation errors, return now
-	if err != nil {
-		return err
+	// Validate it. If it is valid, then we're fine.
+	if err := data.Validate(); err != nil {
+		return fmt.Errorf("Error in customization: %s", err)
 	}
 
-	// Go through the fields, call the callbacks, and record those results
-	for i, d := range data {
-		if d == nil {
-			continue
-		}
-
-		c := opts.Customizations[i]
-		if cerr := c.Callback(d); cerr != nil {
-			err = multierror.Append(err, fmt.Errorf(
-				"Error in '%s' customization: %s", c.Type, cerr))
-			continue
-		}
+	// Call the callback
+	if err := c.Callback(data); err != nil {
+		return fmt.Errorf("Error in customization: %s", err)
 	}
 
-	return err
+	return nil
 }

--- a/helper/compile/foundation.go
+++ b/helper/compile/foundation.go
@@ -24,9 +24,9 @@ type FoundationOptions struct {
 	// default template data if those keys are not set.
 	Bindata *bindata.Data
 
-	// Customizations is a list of helpers to process customizations
-	// in the Appfile. See the Customization docs for more information.
-	Customizations []*Customization
+	// Customization is used to configure the customizations for this
+	// application. See the Customization type docs for more info.
+	Customization *Customization
 
 	// Callbacks are called just prior to compilation completing.
 	Callbacks []CompileCallback
@@ -59,11 +59,9 @@ func Foundation(opts *FoundationOptions) (*foundation.CompileResult, error) {
 	}
 
 	// Process the customizations!
-	err := processCustomizations(&processOpts{
-		Customizations: opts.Customizations,
-		Appfile:        ctx.Appfile,
-		Bindata:        data,
-	})
+	err := processCustomizations(
+		ctx.Appfile.Customization,
+		opts.Customization)
 	if err != nil {
 		return nil, err
 	}

--- a/otto/core_test.go
+++ b/otto/core_test.go
@@ -1,6 +1,8 @@
 package otto
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/otto/app"
@@ -41,6 +43,37 @@ func TestCoreCompile_close(t *testing.T) {
 	}
 	if !appMock.CloseCalled {
 		t.Fatal("close should be called")
+	}
+}
+
+func TestCoreCompile_customizationFilter(t *testing.T) {
+	// Make a core that returns a fixed app
+	coreConfig := TestCoreConfig(t)
+	coreConfig.Appfile = TestAppfile(t, testPath("customization-app-filter", "Appfile"))
+	appMock := TestApp(t, TestAppTuple, coreConfig)
+	core := testCore(t, coreConfig)
+
+	// Compile!
+	if err := core.Compile(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !appMock.CompileCalled {
+		t.Fatal("compile should be called")
+	}
+
+	// Verify our customizations
+	var keys []string
+	for _, c := range appMock.CompileContext.Appfile.Customization.Raw {
+		for k, _ := range c.Config {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	expected := []string{"bar", "foo"}
+	if !reflect.DeepEqual(keys, expected) {
+		t.Fatalf("bad: %#v", keys)
 	}
 }
 

--- a/otto/test-fixtures/customization-app-filter/.ottoid
+++ b/otto/test-fixtures/customization-app-filter/.ottoid
@@ -1,0 +1,13 @@
+4c2fd855-4fa5-0cf8-e279-7c5958a8c9f2
+
+DO NOT MODIFY OR DELETE THIS FILE!
+
+This file should be checked in to version control. Do not ignore this file.
+
+The first line is a unique UUID that represents the Appfile in this directory.
+This UUID is used globally across your projects to identify this specific
+Appfile. This UUID allows you to modify the name of an application, or have
+duplicate application names without conflicting.
+
+If you delete this file, then deploys may duplicate this application since
+Otto will be unable to tell that the application is deployed.

--- a/otto/test-fixtures/customization-app-filter/Appfile
+++ b/otto/test-fixtures/customization-app-filter/Appfile
@@ -1,0 +1,11 @@
+customization "foo" {
+    nope = 1
+}
+
+customization {
+    foo = 1
+}
+
+customization "app" {
+    bar = 1
+}

--- a/website/source/docs/appfile/app.html.md
+++ b/website/source/docs/appfile/app.html.md
@@ -31,6 +31,9 @@ application {
 The `application` block tells Otto about the application that the
 Appfile describes. Only one application block can exist in an Appfile.
 
+More fine-grained configuration of the application is done using
+[customization](/docs/appfile/customization.html) blocks.
+
 The `application` block allows the following keys to be set:
 
   * `name` (string) - The name of the application. This doesn't have

--- a/website/source/docs/appfile/customization.html.md
+++ b/website/source/docs/appfile/customization.html.md
@@ -9,8 +9,8 @@ description: |-
 
 # Customization Configuration
 
-Customization blocks change the behavior of Otto for a specific application
-type or infrastructure.
+Customization blocks change the default behavior of Otto for application types,
+dependencies, infrastructure, and more.
 
 This page assumes you're familiar with the
 [Appfile syntax](/docs/appfile/syntax.html) already.
@@ -20,8 +20,12 @@ This page assumes you're familiar with the
 Customization configuration looks like the following:
 
 ```
-customization "ruby" {
+customization {
     ruby_version = "2.1"
+}
+
+customization "app" {
+    ruby_version = "2.2.3"
 }
 ```
 
@@ -29,21 +33,35 @@ customization "ruby" {
 
 `customization` blocks configure custom behavior for an Appfile that
 deviates from the built-in defaults. Multiple customization blocks
-can be specified, but only one per type (such as "ruby" in the
-example above).
+can be specified. If customization blocks have to be merged, Otto does this
+at a per key level.
 
-The available types of a customization block are defined by the
-application as well as the infrastructure. See the respective documentation
-for those for a list of customization types.
-The contents of a customization block are defined by the type itself
-within the same documentation.
+Customization blocks can be named. The example above shows a customization
+block that is both unnamed and named ("app"). The name of the customization
+block becomes a filter for what the customization applies to.
+
+The available names of customization blocks are well defined. If no name
+is specified, "app" is assumed. The names can be in the following format,
+where all capital letters are placeholders:
+
+  * "" (blank) - Equivalent to "app". See "app" below.
+
+  * "app" - Applies the customization to the app that this Appfile defines.
+
+  * "infra" - Applies the customization to the infrastructure created by
+      this application on deploy.
+
+Within the customization blocks, the available options are dependent on
+the application type or infrastructure type itself. See the respective
+documentation for a reference. For example, see [app types](/docs/apps/index.html)
+for a list of app types and their available customizations.
 
 ## Syntax
 
 The full syntax is:
 
 ```
-customization TYPE {
+customization [FILTER] {
     CONFIG ...
 }
 ```

--- a/website/source/docs/appfile/syntax.html.md
+++ b/website/source/docs/appfile/syntax.html.md
@@ -10,6 +10,11 @@ description: |-
 
 The syntax of Appfiles is [HCL](https://github.com/hashicorp/hcl).
 
+We show what this looks like below as well as a basic syntax guide. The
+actual meaning of the various sections of the Appfile below are documented
+in more specific sections that can be found by navigating to the links to the
+left.
+
 ## HCL
 
 Here is an example of an Appfile:
@@ -25,7 +30,7 @@ application {
 
 /*
 Let's disable this for now
-customization "go" {
+customization {
     go_version = "1.4.2"
 }
 */

--- a/website/source/docs/apps/custom/customization.html.md
+++ b/website/source/docs/apps/custom/customization.html.md
@@ -13,63 +13,26 @@ This page documents the [customizations](/docs/appfile/customization.html)
 that are available to change the behavior of the "custom" application
 type with Otto.
 
-## Type: "dev"
-
 Example:
 
 ```
-customization "dev" {
-    vagrantfile = "./Vagrantfile"
+customization {
+    dev_vagrantfile = "./Vagrantfile"
+    terraform       = "./terraform"
 }
 ```
 
 Available options:
 
-  * `vagrantfile` (string) - Path to a Vagrantfile to use for development.
+  * `dev_vagrantfile` (string) - Path to a Vagrantfile to use for development.
     If this isn't specified, `otto dev` will not work for this application.
     This Vagrantfile will be rendered as a [template](/docs/apps/custom/template.html).
 
-## Type: "dev-dep"
-
-Example:
-
-```
-customization "dev-dep" {
-    vagrantfile = "./Vagrantfile"
-}
-```
-
-Available options:
-
-  * `vagrantfile` (string) - Path to a Vagrantfile to use as a fragment
+  * `dep_vagrantfile` (string) - Path to a Vagrantfile to use as a fragment
     that is embedded in other application's Vagrantfiles when this application
     is being used as a dependency.
 
-## Type: "build"
-
-Example:
-
-```
-customization "build" {
-    packer = "./template.json"
-}
-```
-
-Available options:
-
   * `packer` (string) - Path to a Packer template to execute.
-
-## Type: "deploy"
-
-Example:
-
-```
-customization "deploy" {
-    terraform = "./tf-module"
-}
-```
-
-Available options:
 
   * `terraform` (string) - Path to a Terraform module (directory) to use
     for deployment.

--- a/website/source/docs/apps/docker-external/customization.html.md
+++ b/website/source/docs/apps/docker-external/customization.html.md
@@ -12,12 +12,10 @@ description: |-
 This page documents the [customizations](/docs/appfile/customization.html)
 that are available to change the behavior of Docker applications with Otto.
 
-## Type: "docker"
-
 Example:
 
 ```
-customization "docker" {
+customization {
     image = "mongo:3.0"
 }
 ```

--- a/website/source/docs/apps/go/customization.html.md
+++ b/website/source/docs/apps/go/customization.html.md
@@ -12,12 +12,10 @@ description: |-
 This page documents the [customizations](/docs/appfile/customization.html)
 that are available to change the behavior of Go applications with Otto.
 
-## Type: "go"
-
 Example:
 
 ```
-customization "go" {
+customization {
     go_version = "1.4.2"
 }
 ```
@@ -27,5 +25,5 @@ Available options:
   * `go_version` (string) - The Go version to install for development
     and for building the application for deployment. This defaulits to 1.5.1.
 
-  * `import_path` (string) - The import path of this application so Otto
+  * `go_import_path` (string) - The import path of this application so Otto
     knows where to place it in the GOPATH. Example: "github.com/hashicorp/foo"

--- a/website/source/docs/apps/node/customization.html.md
+++ b/website/source/docs/apps/node/customization.html.md
@@ -12,12 +12,10 @@ description: |-
 This page documents the [customizations](/docs/appfile/customization.html)
 that are available to change the behavior of Node.js applications with Otto.
 
-## Type: "node"
-
 Example:
 
 ```
-customization "node" {
+customization {
     node_version = "4.1.0"
 }
 ```

--- a/website/source/docs/apps/ruby/customization.html.md
+++ b/website/source/docs/apps/ruby/customization.html.md
@@ -12,8 +12,6 @@ description: |-
 This page documents the [customizations](/docs/appfile/customization.html)
 that are available to change the behavior of Ruby applications with Otto.
 
-### Type: "ruby"
-
 Example:
 
 ```

--- a/website/source/docs/concepts/appfile.html.md
+++ b/website/source/docs/concepts/appfile.html.md
@@ -22,7 +22,7 @@ application {
   type = "ruby"
 }
 
-customization "ruby" {
+customization {
   ruby_version = "2.0"
 }
 ```


### PR DESCRIPTION
**Backwards incompatible**

This changes the way customizations are done slightly to be simpler, more well defined, and to lay the foundation for future improvements to customizations.

The configuration _format_ is backwards compatible, but the actual configuration _semantics_ with Otto 0.1 will not be backwards compatible and will require changing your Appfiles very slightly. 

The primary change is making the name/type of a customization block optional. Before, this was required and was a fairly arbitrary string such as "go" that meant something to an app type that might be listening (or might not). To determine what can be customized, visiting the docs was critical.

Now, the naming of a customization block is well defined. See the docs for more info, but I'll reproduce here:

  * "" is the equivalent of "app"

  * "app" will configure the application

  * "infra" will configure the infrastructure

In the future, we'll do things such as:

  * "dependency.NAME" will configure a named dependency

And even farther future, we'll make the names support boolean logic:

  * "dependency.NAME && action == 'dev'" will do what you expect

