### PR TITLE
Add type to the customization block for the examples

### DIFF
--- a/examples/mongodb/Appfile
+++ b/examples/mongodb/Appfile
@@ -3,7 +3,7 @@ application {
     type = "docker-external"
 }
 
-customization {
+customization "docker" {
     image = "mongo:3.0"
     run_args = "-p 27017:27017"
 }

--- a/examples/mysql/Appfile
+++ b/examples/mysql/Appfile
@@ -3,7 +3,7 @@ application {
     type = "docker-external"
 }
 
-customization {
+customization "docker" {
     image = "mysql:5.7"
     run_args = "-p 3306:3306 -e MYSQL_ROOT_PASSWORD=root"
 }

--- a/examples/postgresql/Appfile
+++ b/examples/postgresql/Appfile
@@ -3,7 +3,7 @@ application {
     type = "docker-external"
 }
 
-customization {
+customization "docker" {
     image = "postgres:9.5"
     run_args = "-p 5432:5432"
 }


### PR DESCRIPTION
The provided example for Postgresql cannot be used as dependency right now. During ```otto compile``` the following error will thrown:

```
Error compiling Appfile: Error parsing Appfile in git::https://github.com/hashicorp/otto.git//examples/postgresql: error parsing 'customization': root: not an object type for map (ValueTypeString)
```

In order to get the dependency running, I just added ```docker``` as type to the customization block.