### PR TITLE
Ruby Implicit Dependencies

### DIFF
--- a/builtin/app/ruby/app_test.go
+++ b/builtin/app/ruby/app_test.go
@@ -38,7 +38,7 @@ func TestAppImplicit(t *testing.T) {
 		var ctx app.Context
 		ctx.Appfile = &appfile.File{Path: filepath.Join("./test-fixtures", tc.Dir, "Appfile")}
 
-		// Test it!
+		// Get the implicit file
 		var a App
 		f, err := a.Implicit(&ctx)
 		if err != nil {
@@ -53,13 +53,11 @@ func TestAppImplicit(t *testing.T) {
 			continue
 		}
 
-		// Test the deps
+		// Build the deps we got and sort them for determinism
 		actual := make([]string, 0, len(f.Application.Dependencies))
 		for _, dep := range f.Application.Dependencies {
 			actual = append(actual, dep.Source)
 		}
-
-		// Sort the deps for determinism
 		sort.Strings(actual)
 		sort.Strings(tc.Deps)
 

--- a/builtin/app/ruby/app_test.go
+++ b/builtin/app/ruby/app_test.go
@@ -1,11 +1,71 @@
 package rubyapp
 
 import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/otto/app"
+	"github.com/hashicorp/otto/appfile"
 )
 
 func TestApp_impl(t *testing.T) {
 	var _ app.App = new(App)
+}
+
+func TestAppImplicit(t *testing.T) {
+	cases := []struct {
+		Dir  string
+		Deps []string
+	}{
+		{
+			"implicit-none",
+			nil,
+		},
+
+		{
+			"implicit-redis",
+			[]string{"github.com/hashicorp/otto/examples/redis"},
+		},
+	}
+
+	for _, tc := range cases {
+		errPrefix := fmt.Sprintf("In '%s': ", tc.Dir)
+
+		// Build our context we send in
+		var ctx app.Context
+		ctx.Appfile = &appfile.File{Path: filepath.Join("./test-fixtures", tc.Dir, "Appfile")}
+
+		// Test it!
+		var a App
+		f, err := a.Implicit(&ctx)
+		if err != nil {
+			t.Fatalf("%s: %s", errPrefix, err)
+		}
+		if (len(tc.Deps) == 0) != (f == nil) {
+			// Complicated statement above but basically: should be nil if
+			// we expected no deps, and should not be nil if we expect deps
+			t.Fatalf("%s: deps: %#v\n\ninvalid file: %#v", errPrefix, tc.Deps, f)
+		}
+		if f == nil {
+			continue
+		}
+
+		// Test the deps
+		actual := make([]string, 0, len(f.Application.Dependencies))
+		for _, dep := range f.Application.Dependencies {
+			actual = append(actual, dep.Source)
+		}
+
+		// Sort the deps for determinism
+		sort.Strings(actual)
+		sort.Strings(tc.Deps)
+
+		// Test
+		if !reflect.DeepEqual(actual, tc.Deps) {
+			t.Fatalf("%s\n\ngot: %#v\n\nexpected: %#v", errPrefix, actual, tc.Deps)
+		}
+	}
 }

--- a/builtin/app/ruby/gemfile.go
+++ b/builtin/app/ruby/gemfile.go
@@ -1,0 +1,70 @@
+package rubyapp
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var (
+	// regexp for finding gems in a gemfile
+	gemGemfileRegexp = `\s*gem\s+['"]%s['"]`
+
+	// regexp for finding gems in a gemfile.lock
+	gemGemfileLockRegexp = `\s*%s\s+\(`
+)
+
+// HasGem checks if the Ruby project in the given directory has the
+// specified gem. This uses Gemfile and Gemfile.lock to find this gem.
+//
+// If no Gemfile is in the directory, false is always returned.
+func HasGem(dir, name string) (bool, error) {
+	// Check normal Gemfile
+	ok, err := hasGemGemfile(dir, name)
+	if ok || err != nil {
+		return ok, err
+	}
+
+	// Check Gemfile.lock
+	ok, err = hasGemGemfileLock(dir, name)
+	if ok || err != nil {
+		return ok, err
+	}
+
+	// Nope!
+	return false, nil
+}
+
+func hasGemGemfile(dir, name string) (bool, error) {
+	path := filepath.Join(dir, "Gemfile")
+	reStr := fmt.Sprintf(gemGemfileRegexp, name)
+	return hasGemRaw(path, reStr)
+}
+
+func hasGemGemfileLock(dir, name string) (bool, error) {
+	path := filepath.Join(dir, "Gemfile.lock")
+	reStr := fmt.Sprintf(gemGemfileLockRegexp, name)
+	return hasGemRaw(path, reStr)
+}
+
+func hasGemRaw(path, reStr string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		}
+
+		return false, err
+	}
+
+	// Try to find it!
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	re := regexp.MustCompile(reStr)
+	return re.MatchReader(bufio.NewReader(f)), nil
+}

--- a/builtin/app/ruby/gemfile_test.go
+++ b/builtin/app/ruby/gemfile_test.go
@@ -1,0 +1,51 @@
+package rubyapp
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestHasGem(t *testing.T) {
+	cases := []struct {
+		Dir      string
+		Gem      string
+		Expected bool
+	}{
+		{
+			"hasgem-basic",
+			"redis",
+			true,
+		},
+
+		{
+			"hasgem-basic",
+			"newp",
+			false,
+		},
+
+		{
+			"hasgem-lock-basic",
+			"redis",
+			true,
+		},
+
+		{
+			"hasgem-lock-basic",
+			"newp",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		errPrefix := fmt.Sprintf("In '%s', looking for '%s': ", tc.Dir, tc.Gem)
+		path := filepath.Join("./test-fixtures", tc.Dir)
+		ok, err := HasGem(path, tc.Gem)
+		if err != nil {
+			t.Fatalf("%s: %s", errPrefix, err)
+		}
+		if ok != tc.Expected {
+			t.Fatalf("%s: got %v", errPrefix, ok)
+		}
+	}
+}

--- a/builtin/app/ruby/gemfile_test.go
+++ b/builtin/app/ruby/gemfile_test.go
@@ -35,6 +35,12 @@ func TestHasGem(t *testing.T) {
 			"newp",
 			false,
 		},
+
+		{
+			"hasgem-empty",
+			"newp",
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/builtin/app/ruby/test-fixtures/hasgem-basic/Gemfile
+++ b/builtin/app/ruby/test-fixtures/hasgem-basic/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+ruby "2.1.6"
+
+gem "rails", "4.1.13"
+
+gem "redis",                    "~> 1.5"

--- a/builtin/app/ruby/test-fixtures/hasgem-empty/main.rb
+++ b/builtin/app/ruby/test-fixtures/hasgem-empty/main.rb
@@ -1,0 +1,1 @@
+# Nothing

--- a/builtin/app/ruby/test-fixtures/hasgem-lock-basic/Gemfile.lock
+++ b/builtin/app/ruby/test-fixtures/hasgem-lock-basic/Gemfile.lock
@@ -1,0 +1,13 @@
+GIT
+  remote: git://github.com/hashicorp/vault-rails.git
+  revision: cd17f8474a059adcd911b565d46bea4cedadac5b
+  specs:
+    vault-rails (0.1.2)
+      rails (~> 4.0)
+      vault (~> 0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    redcarpet (3.3.3)
+    redis (3.2.2)

--- a/builtin/app/ruby/test-fixtures/implicit-none/Gemfile
+++ b/builtin/app/ruby/test-fixtures/implicit-none/Gemfile
@@ -1,0 +1,1 @@
+# Nothing

--- a/builtin/app/ruby/test-fixtures/implicit-redis/Gemfile
+++ b/builtin/app/ruby/test-fixtures/implicit-redis/Gemfile
@@ -1,0 +1,1 @@
+gem "redis"

--- a/examples/redis/.ottoid
+++ b/examples/redis/.ottoid
@@ -1,0 +1,13 @@
+a6d8b83a-5ec4-8318-a8ec-20964e865b51
+
+DO NOT MODIFY OR DELETE THIS FILE!
+
+This file should be checked in to version control. Do not ignore this file.
+
+The first line is a unique UUID that represents the Appfile in this directory.
+This UUID is used globally across your projects to identify this specific
+Appfile. This UUID allows you to modify the name of an application, or have
+duplicate application names without conflicting.
+
+If you delete this file, then deploys may duplicate this application since
+Otto will be unable to tell that the application is deployed.

--- a/examples/redis/Appfile
+++ b/examples/redis/Appfile
@@ -1,0 +1,9 @@
+application {
+    name = "redis"
+    type = "docker-external"
+}
+
+customization {
+    image = "redis:3"
+    run_args = "-p 6379:6379"
+}


### PR DESCRIPTION
/cc @justincampbell 

This adds implicit support for Ruby. We inspect the local Gemfile for gems and use that to determine what dependencies to add to the environment.

We are starting with just Redis, but can add more later very very easily. 