### PR TITLE
Detector priority levels

### DIFF
--- a/appfile/detect/config.go
+++ b/appfile/detect/config.go
@@ -34,6 +34,15 @@ type Detector struct {
 	// Contents is a content matcher. The key is a filename and the
 	// path is the file contents regular expression.
 	Contents map[string]string
+
+	// Priority is used to break ties when two detectors conflict.
+	// The detector with the higher (larger number) priority wins.
+	// This defaults to 0. Negative numbers can be used to lower
+	// priority and positive numbers can be used to increase it.
+	//
+	// In most cases, a priority never needs to be set. Please set this
+	// with care.
+	Priority int
 }
 
 // Detect will return true if this detector matches within the given

--- a/appfile/detect/parse_test.go
+++ b/appfile/detect/parse_test.go
@@ -24,6 +24,20 @@ func TestParse(t *testing.T) {
 			},
 			false,
 		},
+
+		{
+			"priority.hcl",
+			&Config{
+				Detectors: []*Detector{
+					&Detector{
+						Type:     "go",
+						File:     []string{"*.go"},
+						Priority: 50,
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/appfile/detect/sort.go
+++ b/appfile/detect/sort.go
@@ -1,0 +1,18 @@
+package detect
+
+// DetectorList is a sortable slice of Detectors, and implements
+// sort.Interface.
+type DetectorList []*Detector
+
+func (l DetectorList) Len() int {
+	return len(l)
+}
+
+func (l DetectorList) Less(i, j int) bool {
+	// Even though this fucntion is "less", we sort by highest priority first.
+	return l[i].Priority > l[j].Priority
+}
+
+func (l DetectorList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}

--- a/appfile/detect/sort_test.go
+++ b/appfile/detect/sort_test.go
@@ -1,0 +1,47 @@
+package detect
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestDetectorList_impl(t *testing.T) {
+	var _ sort.Interface = new(DetectorList)
+}
+
+func TestDetectorList(t *testing.T) {
+	cases := []struct {
+		Input  []*Detector
+		Output []*Detector
+	}{
+		{
+			Input: []*Detector{
+				&Detector{Type: "foo"},
+				&Detector{Type: "bar"},
+			},
+			Output: []*Detector{
+				&Detector{Type: "foo"},
+				&Detector{Type: "bar"},
+			},
+		},
+
+		{
+			Input: []*Detector{
+				&Detector{Type: "foo"},
+				&Detector{Type: "bar", Priority: 10},
+			},
+			Output: []*Detector{
+				&Detector{Type: "bar", Priority: 10},
+				&Detector{Type: "foo"},
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		sort.Sort(DetectorList(tc.Input))
+		if !reflect.DeepEqual(tc.Input, tc.Output) {
+			t.Fatalf("%d\n\nInput: %#v\n\nOutput: %#v", i, tc.Input, tc.Output)
+		}
+	}
+}

--- a/appfile/detect/test-fixtures/parse/priority.hcl
+++ b/appfile/detect/test-fixtures/parse/priority.hcl
@@ -1,0 +1,4 @@
+detect "go" {
+    file = ["*.go"]
+    priority = 50
+}

--- a/builtin/app/node/meta.go
+++ b/builtin/app/node/meta.go
@@ -27,5 +27,10 @@ var Detectors = []*detect.Detector{
 	&detect.Detector{
 		Type: "node",
 		File: []string{"package.json"},
+
+		// Slightly lower priority since many web frameworks can contain
+		// a package.json these days while being written in another
+		// language.
+		Priority: -1,
 	},
 }

--- a/builtin/app/scriptpack/meta.go
+++ b/builtin/app/scriptpack/meta.go
@@ -24,6 +24,10 @@ var Detectors = []*detect.Detector{
 		Contents: map[string]string{
 			"main.go": `^var ScriptPack =`,
 		},
+
+		// High priority for ScriptPacks since it is a very specific
+		// dev environment type.
+		Priority: 10,
 	},
 }
 

--- a/command/compile.go
+++ b/command/compile.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/otto/appfile"
@@ -53,6 +54,9 @@ func (c *CompileCommand) Run(args []string) int {
 	for _, p := range pluginMgr.Plugins() {
 		detectors = append(detectors, p.AppMeta.Detectors...)
 	}
+
+	// Sort the detectors so we try highest priority first
+	sort.Sort(detect.DetectorList(detectors))
 
 	// Parse the detectors
 	dataDir, err := c.DataDir()


### PR DESCRIPTION
This adds the ability to add a priority to detectors, allowing app types to control the order in which detection happens. This should be used VERY sparingly, but we needed it for a couple use cases:

  * `scriptpack` should always beat `go`, it is a more specific version
  * `ruby` should beat `node`, since some Ruby projects contain `package.json` for assets

I purposely didn't document this outside of code, it shouldn't need to be used except in special cases.
