### PR TITLE
app/ruby: Implicit depdendencies for dalli/pg

### DIFF
--- a/builtin/app/ruby/app.go
+++ b/builtin/app/ruby/app.go
@@ -32,6 +32,8 @@ func (a *App) Meta() (*app.Meta, error) {
 func (a *App) Implicit(ctx *app.Context) (*appfile.File, error) {
 	// depMap is our mapping of gem to dependency URL
 	depMap := map[string]string{
+		"dalli": "github.com/hashicorp/otto/examples/memcached",
+		"pg":    "github.com/hashicorp/otto/examples/postgresql",
 		"redis": "github.com/hashicorp/otto/examples/redis",
 	}
 


### PR DESCRIPTION
This adds implicit dependecies for starting Memcached/PostgreSQL Docker containers when the dalli/pg gems are detected.

Needs #386 for Memcached example Appfile