### PR TITLE
app/ruby: Implicit dependencies for mongoid

### DIFF
--- a/builtin/app/ruby/app.go
+++ b/builtin/app/ruby/app.go
@@ -32,9 +32,10 @@ func (a *App) Meta() (*app.Meta, error) {
 func (a *App) Implicit(ctx *app.Context) (*appfile.File, error) {
 	// depMap is our mapping of gem to dependency URL
 	depMap := map[string]string{
-		"dalli": "github.com/hashicorp/otto/examples/memcached",
-		"pg":    "github.com/hashicorp/otto/examples/postgresql",
-		"redis": "github.com/hashicorp/otto/examples/redis",
+		"dalli":   "github.com/hashicorp/otto/examples/memcached",
+		"pg":      "github.com/hashicorp/otto/examples/postgresql",
+		"redis":   "github.com/hashicorp/otto/examples/redis",
+		"mongoid": "github.com/hashicorp/otto/examples/mongodb",
 	}
 
 	// used keeps track of dependencies we've used so we don't


### PR DESCRIPTION
Adds implicit dependencies for starting MongoDB Docker containers when mongoid gem is detected.