### PR TITLE
Make note of Vagrantfile requiring a template extension

### DIFF
--- a/website/source/docs/apps/custom/customization.html.md
+++ b/website/source/docs/apps/custom/customization.html.md
@@ -17,7 +17,7 @@ Example:
 
 ```
 customization {
-    dev_vagrantfile = "./Vagrantfile"
+    dev_vagrantfile = "./Vagrantfile.tpl"
     terraform       = "./terraform"
 }
 ```
@@ -26,7 +26,8 @@ Available options:
 
   * `dev_vagrantfile` (string) - Path to a Vagrantfile to use for development.
     If this isn't specified, `otto dev` will not work for this application.
-    This Vagrantfile will be rendered as a [template](/docs/apps/custom/template.html).
+    This Vagrantfile will be rendered as a [template](/docs/apps/custom/template.html)
+    if the path ends with `.tpl`.
 
   * `dep_vagrantfile` (string) - Path to a Vagrantfile to use as a fragment
     that is embedded in other application's Vagrantfiles when this application

--- a/website/source/docs/apps/custom/dev.html.md
+++ b/website/source/docs/apps/custom/dev.html.md
@@ -25,14 +25,16 @@ application {
 }
 
 customization "dev" {
-    vagrantfile = "./Vagrantfile"
+    vagrantfile = "./Vagrantfile.tpl"
 }
 ```
 
 For the Appfile above, running `otto dev` will run Vagrant in the directory
 of the Appfile against the given Vagrantfile.
 
-The Vagrantfile is rendered as [a template](/docs/apps/custom/template.html).
+The Vagrantfile is rendered as [a template](/docs/apps/custom/template.html)
+if the path ends with `.tpl`.
+
 It is important at the very least to specify the Vagrant shared folder
 should be the working directory. An example Vagrantfile config is shown
 below to do this:

--- a/website/source/docs/apps/custom/index.html.md
+++ b/website/source/docs/apps/custom/index.html.md
@@ -45,7 +45,7 @@ application {
 }
 
 customization "dev" {
-    vagrantfile = "./Vagrantfile"
+    vagrantfile = "./Vagrantfile.tpl"
 }
 
 customization "deploy" {


### PR DESCRIPTION
For customizations, it is currently required that the Vagrantfile ends with `.tpl` to be processed as a template.

Additionally, since the `{{path.working}}` must be specified, I would reason that all examples of custom Appfiles should show usage of `Vagrantfile.tpl` instead of just `Vagrantfile`.