### PR TITLE
Fix typo in appfile.html.md.

### DIFF
--- a/website/source/docs/concepts/appfile.html.md
+++ b/website/source/docs/concepts/appfile.html.md
@@ -60,7 +60,7 @@ an internal representation that is used by all the Otto subcommands,
 such as `otto dev`.
 
 For people writing Appfiles, the important concept to understand here is
-that modifying an Appfile has no affect on the behavior of Otto until
+that modifying an Appfile has no effect on the behavior of Otto until
 that Appfile is compiled.
 
 This is a very useful feature, since modifications to an Appfile that


### PR DESCRIPTION
Simple change from affect -> effect.

Affect is _almost always_ the verb and effect is _almost always_ the noun. This is one of those cases.