### PR TITLE
Add python 3.4 / 3.5 to install.sh

### DIFF
--- a/builtin/scriptpack/python/data/install.sh
+++ b/builtin/scriptpack/python/data/install.sh
@@ -43,6 +43,12 @@ python_install() {
     3.3)
         _python_install_raw "3.3"
         ;;
+    3.4)
+        _python_install_raw "3.4"
+        ;;
+    3.5)
+        _python_install_raw "3.5"
+        ;;
     *)
         echo "Unknown Python version: ${version}" >&2
         exit 1

--- a/builtin/scriptpack/python/test/install.bats
+++ b/builtin/scriptpack/python/test/install.bats
@@ -18,3 +18,19 @@
   virtualenv --version
   [[ $(virtualenv --version 2>&1) =~ '13.' ]]
 }
+
+@test "install from string '3.5'" {
+  python_install "3.5"
+
+  # Verify Python installed
+  python --version
+  [[ $(python --version 2>&1) =~ 'Python 3.5.' ]]
+
+  # Verify pip installed
+  pip --version
+  [[ $(pip --version 2>&1) =~ 'pip' ]]
+
+  # Verify virtualenv
+  virtualenv --version
+  [[ $(virtualenv --version 2>&1) =~ '13.' ]]
+}


### PR DESCRIPTION
This should fix #429 and enable people to use the newer versions of python (which have been out of quite some time now).