### PR TITLE
Prevent race condition in plugin client creation

### DIFF
--- a/plugin/client.go
+++ b/plugin/client.go
@@ -25,7 +25,10 @@ var Killed = false
 
 // This is a slice of the "managed" clients which are cleaned up when
 // calling Cleanup
-var managedClients = make([]*Client, 0, 5)
+var (
+	managedClients     = make([]*Client, 0, 5)
+	managedClientsLock sync.Mutex
+)
 
 // Client handles the lifecycle of a plugin application, determining its
 // RPC address, and returning various types of interface implementations
@@ -133,7 +136,9 @@ func NewClient(config *ClientConfig) (c *Client) {
 
 	c = &Client{config: config}
 	if config.Managed {
+		managedClientsLock.Lock()
 		managedClients = append(managedClients, c)
+		managedClientsLock.Unlock()
 	}
 
 	return


### PR DESCRIPTION
In `plugin.NewClient`, the `managedClients` slice is used to keep track of clients that must be killed when otto exists. `plugin.NewClient` is called by `(*command.Plugin).Load`, which is in turn called by `(*command.PluginManager).LoadAll`. Since `LoadAll` starts multiple goroutines which then call `Load`, a race condition is possible where two or more of these goroutines access `managedClients`  simultaneously.

This commit uses a mutex to prevent this race condition. `NewClient` is the only code that writes to `managedClients`, and `plugin.CleanupClients` is the only other place that `managedClients` is used, but it is called at the end of main goroutine, so a race is not possible there.