### PR TITLE
app/ruby: Implicit depdendencies for mysql2

### DIFF
--- a/builtin/app/ruby/app.go
+++ b/builtin/app/ruby/app.go
@@ -33,6 +33,7 @@ func (a *App) Implicit(ctx *app.Context) (*appfile.File, error) {
 	// depMap is our mapping of gem to dependency URL
 	depMap := map[string]string{
 		"dalli": "github.com/hashicorp/otto/examples/memcached",
+		"mysql2": "github.com/hashicorp/otto/examples/mysql",
 		"pg":    "github.com/hashicorp/otto/examples/postgresql",
 		"redis": "github.com/hashicorp/otto/examples/redis",
 	}


### PR DESCRIPTION
This adds implicit dependecies for starting MySQL Docker containers when the mysql2 gems are detected.