### PR TITLE
Add graphviz dependency for ruby-graphviz

### DIFF
--- a/builtin/scriptpack/ruby/data/gem.sh
+++ b/builtin/scriptpack/ruby/data/gem.sh
@@ -28,6 +28,7 @@ ruby_gemfile_apt() {
     _ruby_gemfile_check libxml-ruby "libxml2-dev"
     _ruby_gemfile_check paperclip "imagemagick"
     _ruby_gemfile_check poltergeist "phantomjs"
+    _ruby_gemfile_check ruby-graphviz "graphviz"
 
     if [ -n "${_ruby_gemfile_queue-}" ]; then
         otto_output "Installing native gem system dependencies..."


### PR DESCRIPTION
The `ruby-graphviz` gem relies on the `graphviz` package.