### PR TITLE
Removed call to `oe` since that function was removed in commit 9dfc8837debed91ea05eaa668837ea845786e6c3

### DIFF
--- a/builtin/app/node/data/common/dev/Vagrantfile.tpl
+++ b/builtin/app/node/data/common/dev/Vagrantfile.tpl
@@ -14,7 +14,7 @@ echo "cd /vagrant" >> /home/vagrant/.profile
 # Configuring SSH for faster login
 if ! grep "UseDNS no" /etc/ssh/sshd_config >/dev/null; then
   echo "UseDNS no" | sudo tee -a /etc/ssh/sshd_config >/dev/null
-  oe sudo service ssh restart
+  sudo service ssh restart
 fi
 
 SCRIPT


### PR DESCRIPTION
A call to `oe` causes all node builds to fail.

See: https://github.com/hashicorp/otto/commit/9dfc8837debed91ea05eaa668837ea845786e6c3#diff-ad0fc33adc8ad73317008324c6bf4ad7L44