### PR TITLE
Add liblapack-dev apt dep for nmatrix-lapacke gem

### DIFF
--- a/builtin/scriptpack/ruby/data/gem.sh
+++ b/builtin/scriptpack/ruby/data/gem.sh
@@ -28,6 +28,7 @@ ruby_gemfile_apt() {
     _ruby_gemfile_check libxml-ruby "libxml2-dev"
     _ruby_gemfile_check paperclip "imagemagick"
     _ruby_gemfile_check poltergeist "phantomjs"
+    _ruby_gemfile_check nmatrix-lapacke "liblapack-dev"
 
     if [ -n "${_ruby_gemfile_queue-}" ]; then
         otto_output "Installing native gem system dependencies..."


### PR DESCRIPTION
Is this the best way to specify gem apt dependencies? Seems like something that could go into customizations in the Appfile. Maybe I missed something obvious?