### PR TITLE
Fixes to make building Otto on Windows easier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh eol=lf
+*.sh.tpl eol=lf

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,6 +49,8 @@ gox \
 # Move all the compiled things to the $GOPATH/bin
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in
+    MSYS*)
+        ;&
     CYGWIN*)
         GOPATH="$(cygpath $GOPATH)"
         ;;


### PR DESCRIPTION
I was trying to build Otto on my Windows box (since the current v0.2.0 release is broken on Windows from issue #445). It looks like to build on Windows we're expected to have Cygwin installed. I don't use Cygwin. I do however have Git for Windows and and a few extra GnuWin32 tools installed which provide all the bits needed to use the provided Makefile and bash build scripts. After getting my environment sorted out so that I was able to build Otto, I discovered that the built executable was still broken and I was unable to follow the otto-getting-started guide because the generated bash scripts for foundation-consul had CRLF line endings which made bash on the VM explode when trying to run them. Hence, this PR.

These changes ensure that:

* The bash scripts get checked out (and thus later compiled) with the correct line-endings, and
* Windows paths get translated to Cygwin-style paths in MSYS bash as well as in Cygwin bash